### PR TITLE
ci: run on Node.js 26 and update actions to v4

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -10,16 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '26.x'
           cache: 'npm'
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
## What

- Run CI on the current Node.js release (`26.x`) instead of the EOL 18.
- Drop the single-entry version matrix (no longer needed for one version).
- Bump `actions/checkout` and `actions/setup-node` to v4.

## Why

Node.js 18 reached end-of-life, so CI was validating against an unsupported runtime. Pinning to the current release keeps CI on a maintained Node.

## Scope

CI configuration only — no changes to published package files, so there is no consumer or API impact and no release is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)