### PR TITLE
Bump version to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0/).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-07-31
+
+### Added
+
+- Svelte 4 support: `peerDependencies` now allows `svelte@^4` alongside `^3.54`.
+
+### Changed
+
+- **Breaking:** upgraded the `rx-nostr` dependency from `^0.8.3` to `^1.5.0`.
+  A `NostrApp` is initialized with an `RxNostr` instance created by the host
+  application, so hosts must upgrade to `rx-nostr@^1` as well.
+- `Nostr` event types are now sourced from `nostr-typedef` instead of being
+  re-exported by `rx-nostr`.
+- Modernized the internal build, test, and lint toolchain (SvelteKit 2, Vite 5,
+  Vitest 3, ESLint 10, Prettier 3) and moved CI to Node.js 26. This does not
+  affect the published package.
+
+[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/akiomik/nosvelte/compare/v0.1.3...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nosvelte",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nosvelte",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/svelte-query": "^4.29.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosvelte",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "author": "Akiomi Kamakura <akiomik@gmail.com>",
   "description": "An experimental Svelte library for building Nostr apps easily",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release v0.2.0. Publishes the consumer-facing changes accumulated on `main` since v0.1.3 (June 2023), which have been unreleased until now.

## Highlights

- **Added:** Svelte 4 support — `peerDependencies` now allows `svelte@^4` alongside `^3.54`.
- **Changed (breaking):** `rx-nostr` dependency `^0.8.3` → `^1.5.0`. A `NostrApp` is initialized with an `RxNostr` instance created by the host app, so hosts must upgrade to `rx-nostr@^1` as well.
- **Changed:** `Nostr` event types are now sourced from `nostr-typedef` instead of `rx-nostr`.
- **Changed (internal):** modernized the build/test/lint toolchain (SvelteKit 2, Vite 5, Vitest 3, ESLint 10, Prettier 3) and moved CI to Node.js 26 — no effect on the published package.

Because `rx-nostr` crosses a major version, this is released as `0.2.0` (breaking changes bump the minor in 0.x).

## Notes

- Adds `CHANGELOG.md` (Keep a Changelog format). It is kept in-repo only and is not added to the package `files` allowlist, so the published tarball is unchanged.
- The next `rx-nostr` upgrade (1.x → 3.x) and `@tanstack/svelte-query` 5 are intentionally deferred to a separate later release.

## After merge

Tag `v0.2.0` on the merge commit and run `npm publish` (requires npm credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)