### PR TITLE
ci: add npm publish workflow using OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # required for npm OIDC trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '26.x'
+          registry-url: 'https://registry.npmjs.org'
+      # Trusted publishing (OIDC) requires npm >= 11.5.1
+      - run: npm install -g npm@latest
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint
+      - run: npm run check
+      # No NODE_AUTH_TOKEN: authentication and provenance come from OIDC
+      - run: npm publish


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` to publish the package to npm on GitHub Release, using **OIDC trusted publishing**.

## Why OIDC trusted publishing

- **No long-lived secret** — no `NPM_TOKEN` stored in the repo. Auth is a short-lived OIDC token exchanged at publish time.
- **Provenance** is generated and attached automatically, so the npm page shows the package was built from this repo/workflow.

## How it works

- Triggers on `release: [published]` (the tag/ref is the released version).
- `permissions: id-token: write` lets the runner request the OIDC token.
- Verifies `test` / `lint` / `check`, then `npm publish` (which builds via `prepublishOnly`). No `NODE_AUTH_TOKEN` is set.
- Uses npm >= 11.5.1 (installed in the job) as required by trusted publishing.

## Required npm-side configuration (done by the maintainer)

On npmjs.com → the `nosvelte` package → **Settings → Trusted Publishing**, add a GitHub Actions publisher:

| Field | Value |
| --- | --- |
| Organization / user | `akiomik` |
| Repository | `nosvelte` |
| Workflow filename | `publish.yml` |
| Environment | *(leave empty; none is used)* |

This workflow must be on the default branch before a Release is published, since release-triggered workflows run from the default branch.

## Publish flow after this merges

1. Merge the version-bump PR (#39).
2. Create a GitHub Release for `v0.2.0` (this creates the tag) → this workflow publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)