### PR TITLE
feat!: upgrade rx-nostr to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** upgraded `rx-nostr` from `^1.5.0` to `^2.0.0` (and `nostr-typedef`
+  to `^0.8.0`). A `NostrApp` is initialized with an `RxNostr` instance created by
+  the host application, so hosts must upgrade to `rx-nostr@^2` as well. See the
+  [rx-nostr v2 release notes](https://github.com/penpenpng/rx-nostr/releases/tag/v2.0.0)
+  for the connection-state renames and other breaking changes.
+
 ## [0.2.0] - 2026-07-31
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/svelte-query": "^4.29.11",
-        "rx-nostr": "^1.5.0"
+        "rx-nostr": "^2.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.0",
@@ -24,7 +24,7 @@
         "eslint-plugin-simple-import-sort": "^14.0.0",
         "eslint-plugin-svelte": "^3.0.0",
         "globals": "^17.0.0",
-        "nostr-typedef": "^0.4.0",
+        "nostr-typedef": "^0.8.0",
         "prettier": "^3.0.0",
         "prettier-plugin-svelte": "^3.0.0",
         "publint": "^0.3.22",
@@ -2664,9 +2664,9 @@
       }
     },
     "node_modules/nostr-typedef": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/nostr-typedef/-/nostr-typedef-0.4.0.tgz",
-      "integrity": "sha512-0hixsTzPHQ0EWGR592mEQFunAk3+0DkgLTXFi5emViMbSpu2f8g5mjjgEgDwjiky047dTfiVw7qMKibZrI5DfQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/nostr-typedef/-/nostr-typedef-0.8.0.tgz",
+      "integrity": "sha512-xJq7ASf7OAKXdJY89bZEAN7ROzX9dokqBHNIvsNKnaROCqQJKjcEZPHftKteHxMh5ko2DCOAnItF6lsB5Oe1iA==",
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -3050,16 +3050,16 @@
       }
     },
     "node_modules/rx-nostr": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/rx-nostr/-/rx-nostr-1.8.1.tgz",
-      "integrity": "sha512-TITUXAvw7LyhqxAYsaAjNtiCJ+NVcedA86+z8CpE4tMudtg8dokDaF+jqzXUkv+/yBwOfRDJi730cA6PICMd+w==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/rx-nostr/-/rx-nostr-2.7.3.tgz",
+      "integrity": "sha512-uQHRrW2Fqla7QiyARn5Kd2t9v3nxPsQFfnzwMjXWfAzvHZoTPcoyxusts9/7bH2gJpCZtNYLHwAEaLtGm6LeyA==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.0.0",
         "@noble/hashes": "^1.3.0",
         "@scure/base": "^1.1.1",
         "normalize-url": "^8.0.0",
-        "nostr-typedef": "^0.4.0",
+        "nostr-typedef": "^0.8.0",
         "rxjs": "^7.8.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^4.29.11",
-    "rx-nostr": "^1.5.0"
+    "rx-nostr": "^2.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
@@ -49,7 +49,7 @@
     "eslint-plugin-simple-import-sort": "^14.0.0",
     "eslint-plugin-svelte": "^3.0.0",
     "globals": "^17.0.0",
-    "nostr-typedef": "^0.4.0",
+    "nostr-typedef": "^0.8.0",
     "prettier": "^3.0.0",
     "prettier-plugin-svelte": "^3.0.0",
     "publint": "^0.3.22",

--- a/src/lib/components/NostrApp.svelte
+++ b/src/lib/components/NostrApp.svelte
@@ -30,7 +30,7 @@
   $: queryClient = new QueryClient(mergedQueryClientConfig);
 
   $: {
-    rxNostr.switchRelays(relays);
+    rxNostr.setDefaultRelays(relays);
     app.set({ rxNostr });
   }
 

--- a/src/lib/stores/useConnections.ts
+++ b/src/lib/stores/useConnections.ts
@@ -20,7 +20,7 @@ export function useConnections({
 
   const init = relays.map((relay) => {
     const from = typeof relay === 'string' ? relay : relay.url;
-    const state = rxNostr.hasRelay(from) ? rxNostr.getRelayState(from) : 'not-started';
+    const state = rxNostr.getRelayState(from) ?? 'initialized';
 
     return { from, state };
   });


### PR DESCRIPTION
Upgrades `rx-nostr` from `^1.5.0` to `^2.0.0` (and `nostr-typedef` `^0.4.0` → `^0.8.0`).

## Consumer impact (breaking)

A `NostrApp` is initialized with an `RxNostr` instance created by the host application, so **hosts must upgrade to `rx-nostr@^2`** as well. This ships in the next release as a minor bump (`0.3.0`) per 0.x semver.

## Changes required by the v2 API

- **`useConnections`**: v2 [renamed connection states](https://github.com/penpenpng/rx-nostr/releases/tag/v2.0.0) — the initial state is now `"initialized"` (was `"not-started"`) — and `getRelayState()` may now return `undefined`. The initial state is computed as `getRelayState(url) ?? "initialized"`, which also covers relays not yet known (replacing the previous `hasRelay()` guard).
- **`NostrApp`**: `switchRelays()` is deprecated in v2 (slated for removal in v3), so it is replaced with `setDefaultRelays()`.

## Verified as unaffected

- Event verification is intact: the `verify()` operator still exists and `createRxNostr()` applies the default verifier.
- The operators in use (`latest`, `latestEach`, `uniq`, `filterKind`, `verify`) keep their names.
- No use of v2-removed features (`fetchAllRelaysInfo`, `setGlobalEventPacketPipe`, the `scope` option, or the renamed config keys).

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 3 passed
- `npm run lint` — clean
- `npm run package` — All good

Version bump to `0.3.0` and the release will be a separate PR; the CHANGELOG entry is staged under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)