### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-31
+
 ### Changed
 
 - **Breaking:** upgraded `rx-nostr` from `^1.5.0` to `^2.0.0` (and `nostr-typedef`
@@ -32,5 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Vitest 3, ESLint 10, Prettier 3) and moved CI to Node.js 26. This does not
   affect the published package.
 
-[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/akiomik/nosvelte/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/akiomik/nosvelte/compare/v0.1.3...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nosvelte",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nosvelte",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/svelte-query": "^4.29.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosvelte",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Akiomi Kamakura <akiomik@gmail.com>",
   "description": "An experimental Svelte library for building Nostr apps easily",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release v0.3.0.

## Changed

- **Breaking:** `rx-nostr` `^1.5.0` → `^2.0.0` (and `nostr-typedef` `^0.4.0` → `^0.8.0`). A `NostrApp` is initialized with an `RxNostr` instance created by the host app, so hosts must upgrade to `rx-nostr@^2` as well.

Because `rx-nostr` crosses a major version, this is released as `0.3.0` (breaking changes bump the minor in 0.x). `svelte-query` and the `svelte` peer range are unchanged.

Promotes the `[Unreleased]` CHANGELOG entry to `[0.3.0]`.

## After merge

Create a GitHub Release for `v0.3.0` (this creates the tag) → the publish workflow publishes to npm via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)