### PR TITLE
feat!: upgrade rx-nostr to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** upgraded `rx-nostr` from `^2.0.0` to `^3.0.0` (and `nostr-typedef`
+  to `^0.13.0`), and added a dependency on `rx-nostr-crypto`. rx-nostr v3 moved
+  cryptographic verification into `rx-nostr-crypto`, so `NostrApp` now creates its
+  `RxNostr` with a `verifier` and events are verified there rather than by a
+  per-request `verify()` operator. Hosts must upgrade to `rx-nostr@^3`; hosts that
+  build their own `RxNostr` should pass a `verifier`. See the
+  [rx-nostr v3 release notes](https://github.com/penpenpng/rx-nostr/releases/tag/v3.0.0).
+- **Breaking:** the exported `RelayConfig` type is renamed to `DefaultRelayConfig`,
+  following rx-nostr v3.
+
 ## [0.3.0] - 2026-07-31
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/svelte-query": "^4.29.11",
-        "rx-nostr": "^2.0.0"
+        "rx-nostr": "^3.0.0",
+        "rx-nostr-crypto": "^3.1.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.0",
@@ -24,7 +25,7 @@
         "eslint-plugin-simple-import-sort": "^14.0.0",
         "eslint-plugin-svelte": "^3.0.0",
         "globals": "^17.0.0",
-        "nostr-typedef": "^0.8.0",
+        "nostr-typedef": "^0.13.0",
         "prettier": "^3.0.0",
         "prettier-plugin-svelte": "^3.0.0",
         "publint": "^0.3.22",
@@ -2651,22 +2652,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-url": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/nostr-typedef": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/nostr-typedef/-/nostr-typedef-0.8.0.tgz",
-      "integrity": "sha512-xJq7ASf7OAKXdJY89bZEAN7ROzX9dokqBHNIvsNKnaROCqQJKjcEZPHftKteHxMh5ko2DCOAnItF6lsB5Oe1iA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/nostr-typedef/-/nostr-typedef-0.13.0.tgz",
+      "integrity": "sha512-CwEC8m83FYKip4ED0nkQa+/tJQpJAKwzc7JgPsunuv26ZpwYqNfc+KvEaKCyM/q5IuKzWuSzsLFtXDfTIm2lkQ==",
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -3050,18 +3039,57 @@
       }
     },
     "node_modules/rx-nostr": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/rx-nostr/-/rx-nostr-2.7.3.tgz",
-      "integrity": "sha512-uQHRrW2Fqla7QiyARn5Kd2t9v3nxPsQFfnzwMjXWfAzvHZoTPcoyxusts9/7bH2gJpCZtNYLHwAEaLtGm6LeyA==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/rx-nostr/-/rx-nostr-3.7.5.tgz",
+      "integrity": "sha512-hmgLIVo22Q5FHfDoWugfr6SyuyeoFgrMT8bjv8LU6jE5NndwvYeZ5SfQOgLZ1p5t19PSU3PQHJBv5dhCcS8bBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.6.0",
+        "nostr-typedef": "^0.13.0",
+        "rxjs": "^7.8.0"
+      }
+    },
+    "node_modules/rx-nostr-crypto": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/rx-nostr-crypto/-/rx-nostr-crypto-3.1.3.tgz",
+      "integrity": "sha512-8WiXCBBMbiFlXs7twmYyPl4+LmwhCI3BeSRtM5jeqvL9BDta/xt825M7iZjih7ChRw9MZWbQZcpFRplM9iIChg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.0.0",
         "@noble/hashes": "^1.3.0",
         "@scure/base": "^1.1.1",
-        "normalize-url": "^8.0.0",
-        "nostr-typedef": "^0.8.0",
-        "rxjs": "^7.8.0"
+        "nostr-typedef": "^0.9.0"
+      },
+      "peerDependencies": {
+        "rx-nostr": "~3"
+      },
+      "peerDependenciesMeta": {
+        "rx-nostr": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/rx-nostr-crypto/node_modules/nostr-typedef": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/nostr-typedef/-/nostr-typedef-0.9.0.tgz",
+      "integrity": "sha512-nLTzhlYcRnLQGUJ5YfvGAUDyGFHjGH6Qozltl/wV3UXelmiUwjrwI8IIxQNkbgVMv+zmbFi/m1xKHxIvVfG09w==",
+      "license": "MIT"
+    },
+    "node_modules/rx-nostr/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/rx-nostr/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@tanstack/svelte-query": "^4.29.11",
-    "rx-nostr": "^2.0.0"
+    "rx-nostr": "^3.0.0",
+    "rx-nostr-crypto": "^3.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
@@ -49,7 +50,7 @@
     "eslint-plugin-simple-import-sort": "^14.0.0",
     "eslint-plugin-svelte": "^3.0.0",
     "globals": "^17.0.0",
-    "nostr-typedef": "^0.8.0",
+    "nostr-typedef": "^0.13.0",
     "prettier": "^3.0.0",
     "prettier-plugin-svelte": "^3.0.0",
     "publint": "^0.3.22",

--- a/src/lib/components/NostrApp.svelte
+++ b/src/lib/components/NostrApp.svelte
@@ -6,16 +6,17 @@
 
   import type { QueryClientConfig } from '@tanstack/svelte-query';
   import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
-  import type { ConnectionStatePacket, RelayConfig } from 'rx-nostr';
+  import type { ConnectionStatePacket, DefaultRelayConfig } from 'rx-nostr';
   import { createRxNostr } from 'rx-nostr';
+  import { verifier } from 'rx-nostr-crypto';
   import { onDestroy } from 'svelte';
 
   import { app, useConnections } from '$lib/stores/index.js';
 
   export let queryClientConfig: QueryClientConfig = {};
-  export let relays: (string | RelayConfig)[] = [];
+  export let relays: (string | DefaultRelayConfig)[] = [];
 
-  const rxNostr = createRxNostr();
+  const rxNostr = createRxNostr({ verifier });
   const defaultQueryClientConfig = {
     defaultOptions: {
       queries: {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,4 +8,4 @@ export * from './stores/index.js';
 export type { QueryClientConfig, QueryKey } from '@tanstack/svelte-query';
 export { QueryClient } from '@tanstack/svelte-query';
 export type * as Nostr from 'nostr-typedef';
-export type { ConnectionStatePacket, EventPacket, RelayConfig, RxNostr } from 'rx-nostr';
+export type { ConnectionStatePacket, DefaultRelayConfig, EventPacket, RxNostr } from 'rx-nostr';

--- a/src/lib/stores/types.ts
+++ b/src/lib/stores/types.ts
@@ -5,11 +5,11 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type Nostr from 'nostr-typedef';
-import type { EventPacket, RelayConfig, RxNostr, RxReq, RxReqController } from 'rx-nostr';
+import type { DefaultRelayConfig, EventPacket, RxNostr, RxReq, RxReqEmittable } from 'rx-nostr';
 import type { OperatorFunction } from 'rxjs';
 import type { Readable } from 'svelte/store';
 
-export type RxReqBase = RxReq & RxReqController;
+export type RxReqBase = RxReq & RxReqEmittable;
 
 export type ReqStatus = 'loading' | 'success' | 'error';
 
@@ -21,7 +21,7 @@ export interface ReqResult<A> {
 
 export interface UseConnectionsOpts {
   rxNostr: RxNostr;
-  relays: (string | RelayConfig)[];
+  relays: (string | DefaultRelayConfig)[];
 }
 
 export interface UseReqOpts<A> {

--- a/src/lib/stores/useArticle.ts
+++ b/src/lib/stores/useArticle.ts
@@ -5,7 +5,7 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { latest, verify } from 'rx-nostr';
+import { latest } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { filterNaddr } from './operators.js';
@@ -20,6 +20,6 @@ export function useArticle(
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket> {
   const filters = [{ kinds: [30023], authors: [pubkey], '#d': [identifier], limit: 1 }];
-  const operator = pipe(filterNaddr(30023, pubkey, identifier), verify(), latest());
+  const operator = pipe(filterNaddr(30023, pubkey, identifier), latest());
   return useReq({ rxNostr, queryKey, filters, operator, req });
 }

--- a/src/lib/stores/useConnections.ts
+++ b/src/lib/stores/useConnections.ts
@@ -20,7 +20,7 @@ export function useConnections({
 
   const init = relays.map((relay) => {
     const from = typeof relay === 'string' ? relay : relay.url;
-    const state = rxNostr.getRelayState(from) ?? 'initialized';
+    const state = rxNostr.getRelayStatus(from)?.connection ?? 'initialized';
 
     return { from, state };
   });

--- a/src/lib/stores/useEvent.ts
+++ b/src/lib/stores/useEvent.ts
@@ -5,7 +5,7 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { uniq, verify } from 'rx-nostr';
+import { uniq } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { filterId } from './operators.js';
@@ -19,6 +19,6 @@ export function useEvent(
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket> {
   const filters = [{ ids: [id], limit: 1 }];
-  const operator = pipe(filterId(id), uniq(), verify());
+  const operator = pipe(filterId(id), uniq());
   return useReq({ rxNostr, queryKey, filters, operator, req });
 }

--- a/src/lib/stores/useEventList.ts
+++ b/src/lib/stores/useEventList.ts
@@ -5,7 +5,7 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { uniq, verify } from 'rx-nostr';
+import { uniq } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { filterTextList, scanArray } from './operators.js';
@@ -19,6 +19,6 @@ export function useEventList(
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket[]> {
   const filters = [{ ids, limit: ids.length }];
-  const operator = pipe(filterTextList(ids), uniq(), verify(), scanArray());
+  const operator = pipe(filterTextList(ids), uniq(), scanArray());
   return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }

--- a/src/lib/stores/useLatestEvent.ts
+++ b/src/lib/stores/useLatestEvent.ts
@@ -6,7 +6,7 @@
 import type { QueryKey } from '@tanstack/svelte-query';
 import type Nostr from 'nostr-typedef';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { latest, verify } from 'rx-nostr';
+import { latest } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import type { ReqResult, RxReqBase } from './types.js';
@@ -18,6 +18,6 @@ export function useLatestEvent(
   filters: Nostr.Filter[],
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket> {
-  const operator = pipe(verify(), latest());
+  const operator = pipe(latest());
   return useReq({ rxNostr, queryKey, filters, operator, req });
 }

--- a/src/lib/stores/useMetadataList.ts
+++ b/src/lib/stores/useMetadataList.ts
@@ -5,7 +5,6 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { verify } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { filterMetadataList, latestEachPubkey, scanArray } from './operators.js';
@@ -20,6 +19,6 @@ export function useMetadataList(
 ): ReqResult<EventPacket[]> {
   // TODO: Add npub support
   const filters = [{ kinds: [0], authors: pubkeys, limit: pubkeys.length }];
-  const operator = pipe(filterMetadataList(pubkeys), verify(), latestEachPubkey(), scanArray());
+  const operator = pipe(filterMetadataList(pubkeys), latestEachPubkey(), scanArray());
   return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }

--- a/src/lib/stores/useReplaceableEvent.ts
+++ b/src/lib/stores/useReplaceableEvent.ts
@@ -5,7 +5,7 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { filterKind, latest, verify } from 'rx-nostr';
+import { filterByKind, latest } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { filterPubkey } from './operators.js';
@@ -21,6 +21,6 @@ export function useReplaceableEvent(
 ): ReqResult<EventPacket> {
   // TODO: Add npub support
   const filters = [{ kinds: [kind], authors: [pubkey], limit: 1 }];
-  const operator = pipe(filterKind(kind), filterPubkey(pubkey), verify(), latest());
+  const operator = pipe(filterByKind(kind), filterPubkey(pubkey), latest());
   return useReq({ rxNostr, queryKey, filters, operator, req });
 }

--- a/src/lib/stores/useReq.ts
+++ b/src/lib/stores/useReq.ts
@@ -22,7 +22,7 @@ export function useReq<A>({
 }: UseReqOpts<A>): ReqResult<A> {
   const queryClient = useQueryClient();
 
-  if (rxNostr.getRelays().length === 0) {
+  if (Object.keys(rxNostr.getDefaultRelays()).length === 0) {
     queryClient.setQueryData(queryKey, initData);
 
     return {

--- a/src/lib/stores/useUniqueEventList.ts
+++ b/src/lib/stores/useUniqueEventList.ts
@@ -6,7 +6,7 @@
 import type { QueryKey } from '@tanstack/svelte-query';
 import type Nostr from 'nostr-typedef';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { uniq, verify } from 'rx-nostr';
+import { uniq } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { scanArray } from './operators.js';
@@ -19,6 +19,6 @@ export function useUniqueEventList(
   filters: Nostr.Filter[],
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket[]> {
-  const operator = pipe(uniq(), verify(), scanArray());
+  const operator = pipe(uniq(), scanArray());
   return useReq({ rxNostr, queryKey, filters, operator, req });
 }

--- a/src/lib/stores/useUserArticleList.ts
+++ b/src/lib/stores/useUserArticleList.ts
@@ -5,7 +5,7 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { filterKind, verify } from 'rx-nostr';
+import { filterByKind } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { filterPubkey, latestEachNaddr, scanArray } from './operators.js';
@@ -20,12 +20,6 @@ export function useUserArticleList(
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket[]> {
   const filters = [{ kinds: [30023], authors: [pubkey], limit }];
-  const operator = pipe(
-    filterKind(30023),
-    filterPubkey(pubkey),
-    verify(),
-    latestEachNaddr(),
-    scanArray()
-  );
+  const operator = pipe(filterByKind(30023), filterPubkey(pubkey), latestEachNaddr(), scanArray());
   return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }

--- a/src/lib/stores/useUserReactionList.ts
+++ b/src/lib/stores/useUserReactionList.ts
@@ -5,7 +5,7 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { filterKind, verify } from 'rx-nostr';
+import { filterByKind } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { filterPubkey, latestEachNaddr, scanArray } from './operators.js';
@@ -20,12 +20,6 @@ export function useUserReactionList(
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket[]> {
   const filters = [{ kinds: [7], authors: [pubkey], limit }];
-  const operator = pipe(
-    filterKind(7),
-    filterPubkey(pubkey),
-    verify(),
-    latestEachNaddr(),
-    scanArray()
-  );
+  const operator = pipe(filterByKind(7), filterPubkey(pubkey), latestEachNaddr(), scanArray());
   return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }

--- a/src/lib/stores/useUserTextList.ts
+++ b/src/lib/stores/useUserTextList.ts
@@ -5,7 +5,7 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { filterKind, uniq, verify } from 'rx-nostr';
+import { filterByKind, uniq } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
 import { filterPubkey, scanArray } from './operators.js';
@@ -21,6 +21,6 @@ export function useUserTextList(
 ): ReqResult<EventPacket[]> {
   // TODO: Add note1 support
   const filters = [{ kinds: [1], authors: [pubkey], limit }];
-  const operator = pipe(filterKind(1), filterPubkey(pubkey), uniq(), verify(), scanArray());
+  const operator = pipe(filterByKind(1), filterPubkey(pubkey), uniq(), scanArray());
   return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }


### PR DESCRIPTION
Upgrades `rx-nostr` from `^2.0.0` to `^3.0.0` (and `nostr-typedef` `^0.8.0` → `^0.13.0`), and adds `rx-nostr-crypto`.

## Consumer impact (breaking)

A `NostrApp` is initialized with an `RxNostr` instance created by the host application, so **hosts must upgrade to `rx-nostr@^3`**. Ships in the next release as `0.4.0` (0.x minor). Two consumer-visible API changes:

- The exported **`RelayConfig` type is renamed `DefaultRelayConfig`** (import update needed).
- Hosts that build their own `RxNostr` (instead of letting `NostrApp` create it) should pass a `verifier` from `rx-nostr-crypto`.

## Why / what changed

rx-nostr v3 [moved cryptography into `rx-nostr-crypto`](https://github.com/penpenpng/rx-nostr/releases/tag/v3.0.0) and made the verifier async.

- **`NostrApp`** now creates the instance with a verifier: `createRxNostr({ verifier })` (from `rx-nostr-crypto`). Events are verified there, so the redundant per-request `verify()` operators are dropped from the store pipes — verification still happens, once, at the rx-nostr layer.
- `filterKind()` → `filterByKind()`.
- `getRelays()` removed → empty-relays check uses `getDefaultRelays()`.
- `getRelayState()` → `getRelayStatus()` (returns `{ connection }`).
- `RxReqController` → `RxReqEmittable` in `RxReqBase`.

All v3.0.0 breaking changes were cross-checked against the codebase; deprecated APIs removed in v3 (e.g. `switchRelays`) were already migrated in the previous release.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 3 passed
- `npm run lint` — clean
- `npm run package` — All good

CHANGELOG staged under `[Unreleased]`; version bump to `0.4.0` will be a separate release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)