### PR TITLE
feat!: upgrade @tanstack/svelte-query to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** upgraded `@tanstack/svelte-query` from `^4.29.11` to `^5.0.0`.
+  Consumers that use `@tanstack/svelte-query` directly (their own `QueryClient`
+  or query hooks) must upgrade to v5 as well, and the exported `QueryClientConfig`
+  and `QueryKey` types now come from v5. See the
+  [TanStack Query v5 migration guide](https://tanstack.com/query/v5/docs/framework/svelte/migration).
+
 ## [0.4.0] - 2026-07-31
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tanstack/svelte-query": "^4.29.11",
+        "@tanstack/svelte-query": "^5.0.0",
         "rx-nostr": "^3.0.0",
         "rx-nostr-crypto": "^3.1.3"
       },
@@ -1266,9 +1266,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
-      "integrity": "sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==",
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1276,19 +1276,19 @@
       }
     },
     "node_modules/@tanstack/svelte-query": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/svelte-query/-/svelte-query-4.44.0.tgz",
-      "integrity": "sha512-ul3PjceVZ0X816npDz+YTc9FZ6NeJMi7TjLzd4Os5ve6FeRB9Ts06csb/g+KDPZeqG+WZeD69LGtjWu7pI33Ug==",
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/svelte-query/-/svelte-query-5.90.2.tgz",
+      "integrity": "sha512-owjnp0w8sOXlMhLZhucHrsYvCjgjHrVyII/wlqMGefxKFyroZS3xCwTee+IUx7UHbL+QmKr/HQTeTqhgxmxPQw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "4.44.0"
+        "@tanstack/query-core": "5.90.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "svelte": ">=3 <5"
+        "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@types/chai": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "svelte": "^3.54.0 || ^4.0.0"
   },
   "dependencies": {
-    "@tanstack/svelte-query": "^4.29.11",
+    "@tanstack/svelte-query": "^5.0.0",
     "rx-nostr": "^3.0.0",
     "rx-nostr-crypto": "^3.1.3"
   },

--- a/src/lib/stores/useReq.ts
+++ b/src/lib/stores/useReq.ts
@@ -44,32 +44,35 @@ export function useReq<A>({
   const error = writable<Error>();
 
   const obs = rxNostr.use(_req).pipe(operator);
-  const query = createQuery<A, Error>(queryKey, () => {
-    return new Promise<A>((resolve, reject) => {
-      let fullfilled = false;
+  const query = createQuery<A, Error>({
+    queryKey,
+    queryFn: () => {
+      return new Promise<A>((resolve, reject) => {
+        let fullfilled = false;
 
-      obs.subscribe({
-        next: (v) => {
-          if (fullfilled) {
-            queryClient.setQueryData(queryKey, v);
-          } else {
-            resolve(v);
-            fullfilled = true;
-          }
-        },
-        complete: () => status.set('success'),
-        error: (e) => {
-          console.error(e);
-          status.set('error');
-          error.set(e);
+        obs.subscribe({
+          next: (v) => {
+            if (fullfilled) {
+              queryClient.setQueryData(queryKey, v);
+            } else {
+              resolve(v);
+              fullfilled = true;
+            }
+          },
+          complete: () => status.set('success'),
+          error: (e) => {
+            console.error(e);
+            status.set('error');
+            error.set(e);
 
-          if (!fullfilled) {
-            reject(e);
-            fullfilled = true;
+            if (!fullfilled) {
+              reject(e);
+              fullfilled = true;
+            }
           }
-        }
+        });
       });
-    });
+    }
   });
 
   return {


### PR DESCRIPTION
Upgrades `@tanstack/svelte-query` from `^4.29.11` to `^5.0.0`.

## Consumer impact (breaking)

`@tanstack/svelte-query` is a direct dependency, so **consumers that use it directly** (their own `QueryClient` or query hooks alongside nosvelte) **must upgrade to v5**. The exported `QueryClientConfig` and `QueryKey` types now come from v5. Ships in the next release as `0.4.0` → `0.5.0` (0.x minor).

The **`svelte` peer range is unchanged**: svelte-query v5 supports Svelte 3/4/5.

## What changed

v5 removed the positional-argument overload of `createQuery`, so `useReq` now passes the object form `createQuery({ queryKey, queryFn })`. No behavior change — the query key and function are identical.

Verified our usage against the v5 breaking changes: we use `createQuery` / `useQueryClient` / `QueryClient` / `QueryClientProvider` / `setQueryData` and `$query.isSuccess`/`isError`/`error`/`data` — none of the removed/renamed v5 APIs (`isLoading`, `cacheTime`, lifecycle callbacks, `keepPreviousData`) are used.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 3 passed
- `npm run lint` — clean
- `npm run package` — All good
- `npm audit` — 11 → 10 (the svelte-query v4 advisory is resolved)

CHANGELOG staged under `[Unreleased]`; version bump to `0.5.0` will be a separate release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)