### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-31
+
 ### Changed
 
 - **Breaking:** upgraded `@tanstack/svelte-query` from `^4.29.11` to `^5.0.0`.
@@ -56,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Vitest 3, ESLint 10, Prettier 3) and moved CI to Node.js 26. This does not
   affect the published package.
 
-[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/akiomik/nosvelte/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/akiomik/nosvelte/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/akiomik/nosvelte/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/akiomik/nosvelte/compare/v0.1.3...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nosvelte",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nosvelte",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/svelte-query": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosvelte",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Akiomi Kamakura <akiomik@gmail.com>",
   "description": "An experimental Svelte library for building Nostr apps easily",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release v0.5.0.

## Changed

- **Breaking:** `@tanstack/svelte-query` `^4.29.11` → `^5.0.0`. It is a direct dependency, so consumers that use `@tanstack/svelte-query` directly must upgrade to v5 as well; the exported `QueryClientConfig` and `QueryKey` types now come from v5.

The `svelte` peer range is unchanged (svelte-query v5 supports Svelte 3/4/5). `rx-nostr` is unchanged. Released as `0.5.0` (breaking changes bump the minor in 0.x).

Promotes the `[Unreleased]` CHANGELOG entry to `[0.5.0]`.

## After merge

Create a GitHub Release for `v0.5.0` (this creates the tag) → the publish workflow publishes to npm via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)