### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-31
+
 ### Added
 
 - Svelte 5 support: the `svelte` peer range is now `^4.0.0 || ^5.0.0`. The
@@ -76,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Vitest 3, ESLint 10, Prettier 3) and moved CI to Node.js 26. This does not
   affect the published package.
 
-[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/akiomik/nosvelte/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/akiomik/nosvelte/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/akiomik/nosvelte/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/akiomik/nosvelte/compare/v0.2.0...v0.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nosvelte",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nosvelte",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/svelte-query": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosvelte",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "Akiomi Kamakura <akiomik@gmail.com>",
   "description": "An experimental Svelte library for building Nostr apps easily",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release v0.6.0.

## Added

- Svelte 5 support: the `svelte` peer range is now `^4.0.0 || ^5.0.0`. Svelte 4 consumers are unaffected (components unchanged; isomorphic type definitions cover both).

## Removed

- **Breaking:** dropped Svelte 3 support (the `svelte` peer range no longer includes `^3`).

## Changed

- Moved the build/test toolchain to the Svelte 5 line (svelte 5, `@sveltejs/vite-plugin-svelte` 7, Vite 8, Vitest 4, prettier-plugin-svelte 4). Dev-only; clears the remaining build-chain advisories (npm audit 10 → 3).

Released as `0.6.0` (0.x minor). Promotes the `[Unreleased]` CHANGELOG entry to `[0.6.0]`.

## After merge

Create a GitHub Release for `v0.6.0` (this creates the tag) → the publish workflow publishes to npm via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)