### PR TITLE
test: cover relay hot paths with a mocked WebSocket relay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-simple-import-sort": "^14.0.0",
         "eslint-plugin-svelte": "^3.0.0",
         "globals": "^17.0.0",
+        "mock-socket": "^9.3.1",
         "nostr-typedef": "^0.13.0",
         "prettier": "^3.0.0",
         "prettier-plugin-svelte": "^4.0.0",
@@ -35,7 +36,8 @@
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.0.0",
         "vite": "^8.0.0",
-        "vitest": "^4.0.0"
+        "vitest": "^4.0.0",
+        "vitest-websocket-mock": "^0.7.0"
       },
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0"
@@ -2347,6 +2349,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -3462,6 +3474,19 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-websocket-mock": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/vitest-websocket-mock/-/vitest-websocket-mock-0.7.0.tgz",
+      "integrity": "sha512-OrDWs/FiZl8MfcCjvxLri1Uq2NpFcqbQdFHuotmU5FgA9Z5PHRxCyHdmu/xSPgBzbxO9pz3ZdHtokFELCT7AOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mock-socket": "^9.2.1"
+      },
+      "peerDependencies": {
+        "vitest": ">=4"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-simple-import-sort": "^14.0.0",
     "eslint-plugin-svelte": "^3.0.0",
     "globals": "^17.0.0",
+    "mock-socket": "^9.3.1",
     "nostr-typedef": "^0.13.0",
     "prettier": "^3.0.0",
     "prettier-plugin-svelte": "^4.0.0",
@@ -60,7 +61,8 @@
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0",
     "vite": "^8.0.0",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "vitest-websocket-mock": "^0.7.0"
   },
   "svelte": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/tests/helpers/relay.ts
+++ b/src/tests/helpers/relay.ts
@@ -1,0 +1,76 @@
+/**
+ * @license Apache-2.0
+ * @copyright 2023 Akiomi Kamakura
+ */
+
+import { WebSocket } from 'mock-socket';
+import type Nostr from 'nostr-typedef';
+import type { EventPacket, IWebSocketConstructor, RxNostr } from 'rx-nostr';
+import { createRxNostr } from 'rx-nostr';
+import WS from 'vitest-websocket-mock';
+
+let fakeEventSeq = 0;
+
+export interface TestRelay {
+  rxNostr: RxNostr;
+  server: WS;
+}
+
+// mock-socket's `WebSocket` is structurally compatible at runtime (send,
+// close, readyState, add/removeEventListener) but its DOM-style overloads
+// don't line up with rx-nostr's narrower `IWebSocketConstructor` type.
+const websocketCtor = WebSocket as unknown as IWebSocketConstructor;
+
+export function createTestRelay(url: string): TestRelay {
+  const server = new WS(url, { jsonProtocol: true });
+  const rxNostr = createRxNostr({
+    websocketCtor,
+    skipVerify: true,
+    skipFetchNip11: true,
+    skipExpirationCheck: true,
+    retry: { strategy: 'off' }
+  });
+  rxNostr.setDefaultRelays([url]);
+
+  return { rxNostr, server };
+}
+
+export function fakeEvent(overrides: Partial<Nostr.Event> = {}): Nostr.Event {
+  fakeEventSeq += 1;
+
+  return {
+    id: `id-${fakeEventSeq}`,
+    pubkey: 'pubkey-1',
+    created_at: fakeEventSeq,
+    kind: 1,
+    tags: [],
+    content: `content-${fakeEventSeq}`,
+    sig: 'sig',
+    ...overrides
+  };
+}
+
+export function fakeEventPacket(overrides: Partial<Nostr.Event> = {}): EventPacket {
+  const event = fakeEvent(overrides);
+
+  return {
+    from: 'wss://relay.example/',
+    type: 'EVENT',
+    subId: 'sub-1',
+    event,
+    message: ['EVENT', 'sub-1', event]
+  };
+}
+
+export async function nextReqSubId(server: WS): Promise<string> {
+  const message = (await server.nextMessage) as [string, string, ...unknown[]];
+  return message[1];
+}
+
+export function respondWithEvent(server: WS, subId: string, event: Nostr.Event): void {
+  server.send(['EVENT', subId, event]);
+}
+
+export function respondWithEose(server: WS, subId: string): void {
+  server.send(['EOSE', subId]);
+}

--- a/src/tests/helpers/store.ts
+++ b/src/tests/helpers/store.ts
@@ -1,0 +1,69 @@
+/**
+ * @license Apache-2.0
+ * @copyright 2023 Akiomi Kamakura
+ */
+
+import type { Readable, Unsubscriber } from 'svelte/store';
+
+/**
+ * `derived()` stores only run their computation once they have a subscriber.
+ * `createQuery()`'s internal store chain is no exception, so a query's
+ * `queryFn` (and thus the REQ it sends) never runs until something
+ * subscribes to one of `useReq()`'s returned stores. Call this right after
+ * `useReq()` to activate it, mirroring what a Svelte component's `$store`
+ * access would do.
+ */
+export function activate<A>(store: Readable<A>): Unsubscriber {
+  return store.subscribe(() => undefined);
+}
+
+export function waitFor<A>(
+  store: Readable<A>,
+  predicate: (value: A) => boolean,
+  timeout = 1000
+): Promise<A> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      unsubscribe();
+      reject(new Error('waitFor: timed out waiting for condition'));
+    }, timeout);
+
+    const unsubscribe = store.subscribe((value) => {
+      if (settled) return;
+
+      // A store can emit values the predicate wasn't written to handle
+      // (e.g. a query's data is genuinely `undefined` while pending, even
+      // though its declared type says otherwise). Treat a throw as "not
+      // matched yet" rather than letting it escape from inside `subscribe()`,
+      // which would leave this callback permanently registered with no way
+      // to unsubscribe.
+      let matched: boolean;
+      try {
+        matched = predicate(value);
+      } catch {
+        matched = false;
+      }
+      if (!matched) return;
+
+      settled = true;
+      clearTimeout(timer);
+      queueMicrotask(() => unsubscribe());
+      resolve(value);
+    });
+  });
+}
+
+export function toArray<A>(store: Readable<A>, timeout: number): Promise<A[]> {
+  return new Promise((resolve) => {
+    const xs: A[] = [];
+    const unsubscribe = store.subscribe((x) => xs.push(x));
+    setTimeout(() => {
+      unsubscribe();
+      resolve(xs);
+    }, timeout);
+  });
+}

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,8 +1,20 @@
 import { vi } from 'vitest';
 
-vi.mock('@tanstack/svelte-query', async () => {
-  const actual: object = await vi.importActual('@tanstack/svelte-query');
-  const useQueryClient = vi.fn();
+// `createQuery()` resolves its `QueryClient` via `getContext()`/`setContext()`
+// internally (see `@tanstack/svelte-query`'s `context.js`), which normally
+// requires running inside a Svelte component. Backing them with a plain Map
+// lets tests provide a `QueryClient` via `setQueryClientContext()` without a
+// real component tree.
+vi.mock('svelte', async () => {
+  const actual: object = await vi.importActual('svelte');
+  const context = new Map<unknown, unknown>();
 
-  return { ...actual, useQueryClient };
+  return {
+    ...actual,
+    getContext: vi.fn((key: unknown) => context.get(key)),
+    setContext: vi.fn((key: unknown, value: unknown) => {
+      context.set(key, value);
+      return value;
+    })
+  };
 });

--- a/src/tests/stores/operators.test.ts
+++ b/src/tests/stores/operators.test.ts
@@ -1,0 +1,182 @@
+import { from, lastValueFrom, toArray } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectGroupBy,
+  filterId,
+  filterMetadataList,
+  filterNaddr,
+  filterPubkey,
+  filterTextList,
+  latestEachNaddr,
+  latestEachPubkey,
+  scanArray,
+  scanLatestEach
+} from '$lib/stores/operators.js';
+
+import { fakeEventPacket } from '../helpers/relay.js';
+
+describe('filterId', () => {
+  it('only passes packets whose event id matches', async () => {
+    const matching = fakeEventPacket({ id: 'a' });
+    const other = fakeEventPacket({ id: 'b' });
+
+    const actual = await lastValueFrom(from([matching, other]).pipe(filterId('a'), toArray()));
+
+    expect(actual).toEqual([matching]);
+  });
+});
+
+describe('filterPubkey', () => {
+  it('only passes packets whose event pubkey matches', async () => {
+    const matching = fakeEventPacket({ pubkey: 'p1' });
+    const other = fakeEventPacket({ pubkey: 'p2' });
+
+    const actual = await lastValueFrom(from([matching, other]).pipe(filterPubkey('p1'), toArray()));
+
+    expect(actual).toEqual([matching]);
+  });
+});
+
+describe('filterTextList', () => {
+  it('only passes kind 1 events whose id is in the given list', async () => {
+    const matching = fakeEventPacket({ id: 'a', kind: 1 });
+    const wrongId = fakeEventPacket({ id: 'z', kind: 1 });
+    const wrongKind = fakeEventPacket({ id: 'a', kind: 0 });
+
+    const actual = await lastValueFrom(
+      from([matching, wrongId, wrongKind]).pipe(filterTextList(['a', 'b']), toArray())
+    );
+
+    expect(actual).toEqual([matching]);
+  });
+});
+
+describe('filterMetadataList', () => {
+  it('only passes kind 0 events whose pubkey is in the given list', async () => {
+    const matching = fakeEventPacket({ pubkey: 'p1', kind: 0 });
+    const wrongPubkey = fakeEventPacket({ pubkey: 'z', kind: 0 });
+    const wrongKind = fakeEventPacket({ pubkey: 'p1', kind: 1 });
+
+    const actual = await lastValueFrom(
+      from([matching, wrongPubkey, wrongKind]).pipe(filterMetadataList(['p1', 'p2']), toArray())
+    );
+
+    expect(actual).toEqual([matching]);
+  });
+});
+
+describe('filterNaddr', () => {
+  it('only passes events matching kind, pubkey and the "d" tag identifier', async () => {
+    const matching = fakeEventPacket({ kind: 30023, pubkey: 'p1', tags: [['d', 'article-1']] });
+    const wrongIdentifier = fakeEventPacket({
+      kind: 30023,
+      pubkey: 'p1',
+      tags: [['d', 'article-2']]
+    });
+    const wrongPubkey = fakeEventPacket({ kind: 30023, pubkey: 'p2', tags: [['d', 'article-1']] });
+    const wrongKind = fakeEventPacket({ kind: 1, pubkey: 'p1', tags: [['d', 'article-1']] });
+
+    const actual = await lastValueFrom(
+      from([matching, wrongIdentifier, wrongPubkey, wrongKind]).pipe(
+        filterNaddr(30023, 'p1', 'article-1'),
+        toArray()
+      )
+    );
+
+    expect(actual).toEqual([matching]);
+  });
+});
+
+describe('latestEachPubkey', () => {
+  it('only passes events that are newer than the latest seen for their pubkey', async () => {
+    const first = fakeEventPacket({ id: 'e1', pubkey: 'p1', created_at: 1 });
+    const newer = fakeEventPacket({ id: 'e2', pubkey: 'p1', created_at: 2 });
+    const stale = fakeEventPacket({ id: 'e3', pubkey: 'p1', created_at: 1 });
+    const otherPubkey = fakeEventPacket({ id: 'e4', pubkey: 'p2', created_at: 1 });
+
+    const actual = await lastValueFrom(
+      from([first, newer, stale, otherPubkey]).pipe(latestEachPubkey(), toArray())
+    );
+
+    expect(actual).toEqual([first, newer, otherPubkey]);
+  });
+});
+
+describe('latestEachNaddr', () => {
+  it('only passes events that are newer than the latest seen for their kind/pubkey/identifier', async () => {
+    const first = fakeEventPacket({
+      id: 'e1',
+      kind: 30023,
+      pubkey: 'p1',
+      tags: [['d', 'article-1']],
+      created_at: 1
+    });
+    const newer = fakeEventPacket({
+      id: 'e2',
+      kind: 30023,
+      pubkey: 'p1',
+      tags: [['d', 'article-1']],
+      created_at: 2
+    });
+    const stale = fakeEventPacket({
+      id: 'e3',
+      kind: 30023,
+      pubkey: 'p1',
+      tags: [['d', 'article-1']],
+      created_at: 1
+    });
+    const otherIdentifier = fakeEventPacket({
+      id: 'e4',
+      kind: 30023,
+      pubkey: 'p1',
+      tags: [['d', 'article-2']],
+      created_at: 1
+    });
+
+    const actual = await lastValueFrom(
+      from([first, newer, stale, otherIdentifier]).pipe(latestEachNaddr(), toArray())
+    );
+
+    expect(actual).toEqual([first, newer, otherIdentifier]);
+  });
+});
+
+describe('scanArray', () => {
+  it('accumulates emitted values into a growing array', async () => {
+    const actual = await lastValueFrom(from([1, 2, 3]).pipe(scanArray(), toArray()));
+
+    expect(actual).toEqual([[1], [1, 2], [1, 2, 3]]);
+  });
+});
+
+describe('collectGroupBy', () => {
+  it('groups accumulated values by key into a Map', async () => {
+    const actual = await lastValueFrom(
+      from([1, 2, 3, 4]).pipe(
+        collectGroupBy((n) => (n % 2 === 0 ? 'even' : 'odd')),
+        toArray()
+      )
+    );
+
+    expect(actual.at(-1)).toEqual(
+      new Map([
+        ['odd', [1, 3]],
+        ['even', [2, 4]]
+      ])
+    );
+  });
+});
+
+describe('scanLatestEach', () => {
+  it('keeps only the last value seen for each key, in first-seen order', async () => {
+    const actual = await lastValueFrom(
+      from(['p1-a', 'p2-a', 'p1-b']).pipe(
+        scanLatestEach((s) => s.slice(0, 2)),
+        toArray()
+      )
+    );
+
+    expect(actual.at(-1)).toEqual(['p1-b', 'p2-a']);
+  });
+});

--- a/src/tests/stores/useConnections.test.ts
+++ b/src/tests/stores/useConnections.test.ts
@@ -1,0 +1,60 @@
+import type { ConnectionStatePacket } from 'rx-nostr';
+import { createRxForwardReq } from 'rx-nostr';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useConnections } from '$lib/stores/useConnections.js';
+
+import { createTestRelay } from '../helpers/relay.js';
+
+describe('useConnections', () => {
+  afterEach(() => {
+    WS.clean();
+  });
+
+  describe('when relays are empty', () => {
+    it('emits an empty snapshot once', async () => {
+      const { rxNostr } = createTestRelay('ws://localhost:9201');
+
+      const snapshots: ConnectionStatePacket[][] = [];
+      const subscription = useConnections({ rxNostr, relays: [] }).subscribe((s) =>
+        snapshots.push(s)
+      );
+      subscription.unsubscribe();
+
+      expect(snapshots).toEqual([[]]);
+    });
+  });
+
+  describe('when relays are configured', () => {
+    it('seeds the initial snapshot from current relay status, then keeps only the latest state per relay', async () => {
+      const url = 'ws://localhost:9202';
+      const { rxNostr, server } = createTestRelay(url);
+
+      const snapshots: ConnectionStatePacket[][] = [];
+      const subscription = useConnections({ rxNostr, relays: [url] }).subscribe((s) =>
+        snapshots.push(s)
+      );
+
+      expect(snapshots[0]).toEqual([{ from: url, state: 'initialized' }]);
+
+      const req = createRxForwardReq();
+      rxNostr.use(req).subscribe();
+      req.emit([{}]);
+      await server.connected;
+
+      await vi.waitFor(() => {
+        expect(snapshots.at(-1)).toEqual([{ from: url, state: 'connected' }]);
+      });
+
+      server.close();
+
+      // With retries turned off, an unexpected close is a terminal "error".
+      await vi.waitFor(() => {
+        expect(snapshots.at(-1)).toEqual([{ from: url, state: 'error' }]);
+      });
+
+      subscription.unsubscribe();
+    });
+  });
+});

--- a/src/tests/stores/useEvent.test.ts
+++ b/src/tests/stores/useEvent.test.ts
@@ -1,0 +1,49 @@
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useEvent } from '$lib/stores/useEvent.js';
+
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, waitFor } from '../helpers/store.js';
+
+describe('useEvent', () => {
+  beforeEach(() => {
+    setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('requests the given id and resolves with the matching event, ignoring duplicates', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9301');
+    const id = 'target-id';
+
+    const result = useEvent(rxNostr, ['useEvent'], id);
+    activate(result.status);
+
+    const subId = await nextReqSubId(server);
+    expect(server.messages.at(-1)).toEqual(['REQ', subId, { ids: [id], limit: 1 }]);
+
+    const event = fakeEvent({ id });
+    respondWithEvent(server, subId, event);
+    const data = await waitFor(result.data, (v) => v !== undefined);
+    expect(data?.event).toEqual(event);
+
+    // A second EVENT with the same id is deduplicated by `uniq()` and never
+    // reaches the query, so .data must not change.
+    respondWithEvent(server, subId, fakeEvent({ id, content: 'duplicate-should-be-ignored' }));
+    respondWithEose(server, subId);
+
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data)?.event).toEqual(event);
+  });
+});

--- a/src/tests/stores/useEventList.test.ts
+++ b/src/tests/stores/useEventList.test.ts
@@ -1,0 +1,54 @@
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useEventList } from '$lib/stores/useEventList.js';
+
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, waitFor } from '../helpers/store.js';
+
+describe('useEventList', () => {
+  beforeEach(() => {
+    setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('requests the given ids and accumulates matching kind-1 events, deduplicating and ignoring others', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9302');
+    const ids = ['a', 'b'];
+
+    const result = useEventList(rxNostr, ['useEventList'], ids);
+    activate(result.status);
+
+    const subId = await nextReqSubId(server);
+    expect(server.messages.at(-1)).toEqual(['REQ', subId, { ids, limit: ids.length }]);
+
+    const eventA = fakeEvent({ id: 'a', kind: 1 });
+    respondWithEvent(server, subId, eventA);
+    await waitFor(result.data, (v) => v.length === 1);
+
+    const eventB = fakeEvent({ id: 'b', kind: 1 });
+    respondWithEvent(server, subId, eventB);
+    const twoEvents = await waitFor(result.data, (v) => v.length === 2);
+    expect(twoEvents.map((p) => p.event)).toEqual([eventA, eventB]);
+
+    // Ignored: duplicate id, id not in the requested list, and wrong kind.
+    respondWithEvent(server, subId, fakeEvent({ id: 'a', kind: 1, content: 'duplicate' }));
+    respondWithEvent(server, subId, fakeEvent({ id: 'z', kind: 1 }));
+    respondWithEvent(server, subId, fakeEvent({ id: 'a', kind: 0 }));
+    respondWithEose(server, subId);
+
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data).map((p) => p.event)).toEqual([eventA, eventB]);
+  });
+});

--- a/src/tests/stores/useMetadata.test.ts
+++ b/src/tests/stores/useMetadata.test.ts
@@ -1,0 +1,63 @@
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useMetadata } from '$lib/stores/useMetadata.js';
+
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, waitFor } from '../helpers/store.js';
+
+describe('useMetadata', () => {
+  beforeEach(() => {
+    setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('requests kind-0 events for the given pubkey and keeps only the newest one', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9303');
+    const pubkey = 'p1';
+
+    const result = useMetadata(rxNostr, ['useMetadata'], pubkey);
+    activate(result.status);
+
+    const subId = await nextReqSubId(server);
+    expect(server.messages.at(-1)).toEqual([
+      'REQ',
+      subId,
+      { kinds: [0], authors: [pubkey], limit: 1 }
+    ]);
+
+    const first = fakeEvent({ id: 'e1', kind: 0, pubkey, created_at: 1 });
+    respondWithEvent(server, subId, first);
+    const data = await waitFor(result.data, (v) => v !== undefined);
+    expect(data?.event).toEqual(first);
+
+    // Newer replaces the current value.
+    const newer = fakeEvent({ id: 'e2', kind: 0, pubkey, created_at: 2 });
+    respondWithEvent(server, subId, newer);
+    await waitFor(result.data, (v) => v?.event.id === 'e2');
+
+    // Ignored: stale (older) update, wrong kind, and wrong pubkey.
+    respondWithEvent(server, subId, fakeEvent({ id: 'e3', kind: 0, pubkey, created_at: 1 }));
+    respondWithEvent(server, subId, fakeEvent({ id: 'e4', kind: 1, pubkey, created_at: 3 }));
+    respondWithEvent(
+      server,
+      subId,
+      fakeEvent({ id: 'e5', kind: 0, pubkey: 'other', created_at: 3 })
+    );
+    respondWithEose(server, subId);
+
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data)?.event).toEqual(newer);
+  });
+});

--- a/src/tests/stores/useReq.test.ts
+++ b/src/tests/stores/useReq.test.ts
@@ -1,18 +1,19 @@
-import { QueryClient, useQueryClient } from '@tanstack/svelte-query';
-import { createRxNostr } from 'rx-nostr';
-import { pipe } from 'rxjs';
-import type { Readable } from 'svelte/store';
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { createRxForwardReq, createRxNostr } from 'rx-nostr';
+import { map, pipe } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import WS from 'vitest-websocket-mock';
 
 import { useReq } from '$lib/stores/useReq.js';
 
-function toArray<A>(store: Readable<A>, timeout: number): Promise<A[]> {
-  return new Promise((resolve) => {
-    const xs: A[] = [];
-    store.subscribe((x) => xs.push(x));
-    setTimeout(() => resolve(xs), timeout);
-  });
-}
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, toArray, waitFor } from '../helpers/store.js';
 
 describe('useReq', () => {
   const queryKey = ['useReq'];
@@ -22,7 +23,7 @@ describe('useReq', () => {
   const initData = undefined;
 
   beforeEach(() => {
-    vi.mocked(useQueryClient).mockImplementation(() => new QueryClient());
+    setQueryClientContext(new QueryClient());
   });
 
   afterEach(() => {
@@ -47,6 +48,118 @@ describe('useReq', () => {
       const result = useReq({ rxNostr, queryKey, filters, operator, initData });
       const actual = await toArray(result.error, 250);
       expect(actual).toEqual([undefined]);
+    });
+  });
+
+  describe('when relays are configured', () => {
+    beforeEach(() => {
+      setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+    });
+
+    afterEach(() => {
+      WS.clean();
+    });
+
+    it('resolves .data with the first event and transitions .status to "success"', async () => {
+      const { rxNostr, server } = createTestRelay('ws://localhost:9001');
+      const result = useReq({
+        rxNostr,
+        queryKey: ['useReq', 'success'],
+        filters: [{ kinds: [1] }],
+        operator: pipe(),
+        initData: undefined
+      });
+      activate(result.status);
+
+      const subId = await nextReqSubId(server);
+      const event = fakeEvent();
+      respondWithEvent(server, subId, event);
+
+      const data = await waitFor(result.data, (v) => v !== undefined);
+      expect(data?.event).toEqual(event);
+      // The underlying query resolves as soon as the first matching event
+      // arrives; EOSE isn't required for .status to become "success".
+      expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+
+      respondWithEose(server, subId);
+    });
+
+    it('updates .data with subsequent events received before EOSE', async () => {
+      const { rxNostr, server } = createTestRelay('ws://localhost:9002');
+      const result = useReq({
+        rxNostr,
+        queryKey: ['useReq', 'streaming'],
+        filters: [{ kinds: [1] }],
+        operator: pipe(),
+        initData: undefined
+      });
+      activate(result.status);
+
+      const subId = await nextReqSubId(server);
+      const first = fakeEvent();
+      const second = fakeEvent();
+      respondWithEvent(server, subId, first);
+      await waitFor(result.data, (v) => v?.event.id === first.id);
+
+      respondWithEvent(server, subId, second);
+      const data = await waitFor(result.data, (v) => v?.event.id === second.id);
+      expect(data?.event).toEqual(second);
+
+      respondWithEose(server, subId);
+      expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    });
+
+    it('sets .status to "error" and .error when the operator throws', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const { rxNostr, server } = createTestRelay('ws://localhost:9003');
+      const result = useReq({
+        rxNostr,
+        queryKey: ['useReq', 'error'],
+        filters: [{ kinds: [1] }],
+        operator: pipe(
+          map(() => {
+            throw new Error('boom');
+          })
+        ),
+        initData: undefined
+      });
+      activate(result.status);
+
+      const subId = await nextReqSubId(server);
+      respondWithEvent(server, subId, fakeEvent());
+
+      const status = await waitFor(result.status, (s) => s === 'error');
+      expect(status).toBe('error');
+      const error = await waitFor(result.error, (e) => e !== undefined);
+      expect(error?.message).toBe('boom');
+      expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('reuses a given req to emit filters instead of creating a new oneshot req', () => {
+      const { rxNostr } = createTestRelay('ws://localhost:9004');
+      const req = createRxForwardReq();
+      const emitSpy = vi.spyOn(req, 'emit');
+      const filters = [{ kinds: [1] }];
+
+      // `req`'s own packet stream is the source of truth for what useReq()
+      // asked it to emit, independent of whether/when the internal query
+      // machinery subscribes to it.
+      const packets: unknown[] = [];
+      const subscription = req.getReqPacketObservable().subscribe((packet) => packets.push(packet));
+
+      useReq({
+        rxNostr,
+        queryKey: ['useReq', 'req-reuse'],
+        filters,
+        operator: pipe(),
+        req,
+        initData: undefined
+      });
+
+      expect(emitSpy).toHaveBeenCalledWith(filters);
+      expect(packets).toEqual([{ filters }]);
+
+      subscription.unsubscribe();
     });
   });
 });

--- a/src/tests/stores/useUniqueEventList.test.ts
+++ b/src/tests/stores/useUniqueEventList.test.ts
@@ -1,0 +1,52 @@
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useUniqueEventList } from '$lib/stores/useUniqueEventList.js';
+
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, waitFor } from '../helpers/store.js';
+
+describe('useUniqueEventList', () => {
+  beforeEach(() => {
+    setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('requests the given filters and accumulates events, deduplicating by id', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9304');
+    const filters = [{ kinds: [1] }];
+
+    const result = useUniqueEventList(rxNostr, ['useUniqueEventList'], filters);
+    activate(result.status);
+
+    const subId = await nextReqSubId(server);
+    expect(server.messages.at(-1)).toEqual(['REQ', subId, filters[0]]);
+
+    const first = fakeEvent({ id: 'e1' });
+    respondWithEvent(server, subId, first);
+    await waitFor(result.data, (v) => v.length === 1);
+
+    const second = fakeEvent({ id: 'e2' });
+    respondWithEvent(server, subId, second);
+    const twoEvents = await waitFor(result.data, (v) => v.length === 2);
+    expect(twoEvents.map((p) => p.event)).toEqual([first, second]);
+
+    // A duplicate id is deduplicated and must not grow the accumulated list.
+    respondWithEvent(server, subId, fakeEvent({ id: 'e1', content: 'duplicate' }));
+    respondWithEose(server, subId);
+
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data).map((p) => p.event)).toEqual([first, second]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `vitest-websocket-mock` + `mock-socket`, wired into rx-nostr via `websocketCtor`, so tests can drive a real REQ/EVENT/EOSE round-trip against an in-process mock relay instead of only the empty-relays early return.
- Add shared test helpers (`src/tests/helpers/relay.ts`, `src/tests/helpers/store.ts`) for spinning up a mock relay + `RxNostr`, building fake events, and waiting on Svelte store values.
- Mock `svelte`'s `getContext`/`setContext` in `src/tests/setup.ts` so `createQuery()` can resolve a `QueryClient` via `setQueryClientContext()` without a real component tree.
- Expand `useReq.test.ts` with the relay-configured hot path: success/streaming updates, operator-thrown errors, and external `req` reuse.
- Add `operators.test.ts` covering the pure filter/latestEach/scan operator functions.
- Add `useConnections.test.ts` covering the empty-relays case and real connection-state transitions.
- Add tests for four representative derived hooks (`useEvent`, `useEventList`, `useMetadata`, `useUniqueEventList`) exercising their distinct operator compositions (`uniq`, `scanArray`, `latest`) end-to-end.

## Test plan
- [x] `npm run test` (23/23 passing)
- [x] `npm run lint`
- [x] `npm run check`