### PR TITLE
fix(stores): handle REQs that match no events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   indefinitely. The query now settles on completion, and `data` falls back to the
   hook's initial value (`[]` for the list hooks, `undefined` for the single-event
   ones) for the whole request rather than only before the first emission.
+- `useUniqueEventList()` now yields `[]` instead of `undefined` when no relays are
+  configured, matching the other list hooks and its own `EventPacket[]` return type.
+  `UniqueEventList` was unaffected, but callers using the hook directly could hit a
+  `TypeError` on the `undefined` the type said could not occur.
 
 ## [0.6.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A request whose filters match no event no longer hangs. Such a REQ reaches
+  EOSE without the operator chain ever emitting, which left the underlying query
+  pending forever: `status` reported `'success'` while `data` stayed `undefined`
+  indefinitely. The query now settles on completion, and `data` falls back to the
+  hook's initial value (`[]` for the list hooks, `undefined` for the single-event
+  ones) for the whole request rather than only before the first emission.
+
 ## [0.6.0] - 2026-07-31
 
 ### Added

--- a/src/lib/stores/useReq.ts
+++ b/src/lib/stores/useReq.ts
@@ -59,7 +59,22 @@ export function useReq<A>({
               fullfilled = true;
             }
           },
-          complete: () => status.set('success'),
+          complete: () => {
+            status.set('success');
+
+            // A REQ that matches nothing completes on EOSE without ever
+            // emitting: `latest()` scans without a seed and `scanArray()`'s
+            // seed only surfaces once the source emits. Resolving here keeps
+            // the query from staying pending forever, which would otherwise
+            // leave `.status` reporting 'success' while `.data` never
+            // settles. TanStack Query rejects `undefined` as query data, so
+            // `null` stands in for "completed with no events" and is mapped
+            // back to `initData` below.
+            if (!fullfilled) {
+              resolve((initData ?? null) as A);
+              fullfilled = true;
+            }
+          },
           error: (e) => {
             console.error(e);
             status.set('error');
@@ -76,7 +91,12 @@ export function useReq<A>({
   });
 
   return {
-    data: derived(query, ($query) => $query.data as A, initData),
+    // `createQuery()`'s store emits synchronously on subscribe, so `derived()`'s
+    // initial value is replaced by `$query.data` right away — including while
+    // the query is still pending, when that data is `undefined`. Falling back
+    // to `initData` makes it the value seen throughout a request, not just
+    // before the first emission, and maps the `null` resolved above back to it.
+    data: derived(query, ($query) => ($query.data ?? initData) as A, initData),
     status: derived([query, status], ([$query, $status]) => {
       if ($query.isSuccess) {
         return 'success';

--- a/src/lib/stores/useReq.ts
+++ b/src/lib/stores/useReq.ts
@@ -48,15 +48,15 @@ export function useReq<A>({
     queryKey,
     queryFn: () => {
       return new Promise<A>((resolve, reject) => {
-        let fullfilled = false;
+        let fulfilled = false;
 
         obs.subscribe({
           next: (v) => {
-            if (fullfilled) {
+            if (fulfilled) {
               queryClient.setQueryData(queryKey, v);
             } else {
               resolve(v);
-              fullfilled = true;
+              fulfilled = true;
             }
           },
           complete: () => {
@@ -70,9 +70,9 @@ export function useReq<A>({
             // settles. TanStack Query rejects `undefined` as query data, so
             // `null` stands in for "completed with no events" and is mapped
             // back to `initData` below.
-            if (!fullfilled) {
+            if (!fulfilled) {
               resolve((initData ?? null) as A);
-              fullfilled = true;
+              fulfilled = true;
             }
           },
           error: (e) => {
@@ -80,9 +80,9 @@ export function useReq<A>({
             status.set('error');
             error.set(e);
 
-            if (!fullfilled) {
+            if (!fulfilled) {
               reject(e);
-              fullfilled = true;
+              fulfilled = true;
             }
           }
         });

--- a/src/lib/stores/useUniqueEventList.ts
+++ b/src/lib/stores/useUniqueEventList.ts
@@ -20,5 +20,5 @@ export function useUniqueEventList(
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket[]> {
   const operator = pipe(uniq(), scanArray());
-  return useReq({ rxNostr, queryKey, filters, operator, req });
+  return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }

--- a/src/tests/stores/useReq.test.ts
+++ b/src/tests/stores/useReq.test.ts
@@ -1,9 +1,12 @@
 import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
-import { createRxForwardReq, createRxNostr } from 'rx-nostr';
+import type { EventPacket } from 'rx-nostr';
+import { createRxForwardReq, createRxNostr, latest } from 'rx-nostr';
 import { map, pipe } from 'rxjs';
+import { get } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import WS from 'vitest-websocket-mock';
 
+import { scanArray } from '$lib/stores/operators.js';
 import { useReq } from '$lib/stores/useReq.js';
 
 import {
@@ -107,6 +110,68 @@ describe('useReq', () => {
 
       respondWithEose(server, subId);
       expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    });
+
+    it('settles the query when the REQ completes without emitting anything', async () => {
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      setQueryClientContext(queryClient);
+
+      const { rxNostr, server } = createTestRelay('ws://localhost:9005');
+      const queryKey = ['useReq', 'empty'];
+      const result = useReq({
+        rxNostr,
+        queryKey,
+        filters: [{ kinds: [1] }],
+        // `latest()` scans without a seed, so a REQ that matches nothing
+        // reaches EOSE having emitted no value at all.
+        operator: pipe(latest()),
+        initData: undefined
+      });
+      activate(result.status);
+      activate(result.data);
+
+      const subId = await nextReqSubId(server);
+      respondWithEose(server, subId);
+
+      expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+      // The local `status` store reaching 'success' isn't enough: the query
+      // behind it must settle too, or it stays pending (and fetching) forever
+      // while .status already claims success.
+      await vi.waitFor(() => {
+        expect(queryClient.getQueryState(queryKey)?.status).toBe('success');
+      });
+      expect(queryClient.getQueryState(queryKey)?.fetchStatus).toBe('idle');
+      expect(get(result.data)).toBeUndefined();
+    });
+
+    it('resolves with initData when the REQ completes without emitting anything', async () => {
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      setQueryClientContext(queryClient);
+
+      const { rxNostr, server } = createTestRelay('ws://localhost:9006');
+      const queryKey = ['useReq', 'empty-list'];
+      const result = useReq<EventPacket[]>({
+        rxNostr,
+        queryKey,
+        filters: [{ kinds: [1] }],
+        // `scanArray()`'s `[]` seed is only surfaced once the source emits, so
+        // this operator is just as silent as `latest()` on an empty result.
+        operator: pipe(scanArray()),
+        initData: []
+      });
+      activate(result.status);
+      activate(result.data);
+
+      const subId = await nextReqSubId(server);
+      respondWithEose(server, subId);
+
+      expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+      // Asserted against the cache rather than `.data`, which falls back to
+      // `initData` while pending and so can't tell resolution apart from it.
+      await vi.waitFor(() => {
+        expect(queryClient.getQueryData(queryKey)).toEqual([]);
+      });
+      expect(get(result.data)).toEqual([]);
     });
 
     it('sets .status to "error" and .error when the operator throws', async () => {

--- a/src/tests/stores/useUniqueEventList.test.ts
+++ b/src/tests/stores/useUniqueEventList.test.ts
@@ -1,4 +1,5 @@
 import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { createRxNostr } from 'rx-nostr';
 import { get } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import WS from 'vitest-websocket-mock';
@@ -48,5 +49,33 @@ describe('useUniqueEventList', () => {
 
     expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
     expect(get(result.data).map((p) => p.event)).toEqual([first, second]);
+  });
+
+  it('emits an empty list when the REQ matches no events', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9305');
+
+    const result = useUniqueEventList(rxNostr, ['useUniqueEventList', 'empty'], [{ kinds: [1] }]);
+    activate(result.status);
+    activate(result.data);
+
+    respondWithEose(server, await nextReqSubId(server));
+
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data)).toEqual([]);
+  });
+
+  it('emits an empty list when no relays are configured', () => {
+    const rxNostr = createRxNostr();
+
+    const result = useUniqueEventList(
+      rxNostr,
+      ['useUniqueEventList', 'no-relays'],
+      [{ kinds: [1] }]
+    );
+
+    // The relay-less early return hands back `initData` verbatim, so omitting
+    // it would break the `EventPacket[]` contract with `undefined`.
+    expect(get(result.data)).toEqual([]);
+    expect(get(result.status)).toBe('success');
   });
 });


### PR DESCRIPTION
A REQ whose filters match nothing never produced a usable result. This fixes
both halves of that: the query that never settled, and the one list hook that
never declared an empty initial value.

## The hang

`useReq()` resolves its queryFn promise only from `next`. But a REQ that matches
nothing reaches EOSE without the operator chain emitting at all:

- rx-nostr's `latest()` uses `scan()` with no seed, and RxJS's seedless `scan`
  emits nothing if the source completes without a value.
- `scanArray()` does have a `[]` seed, but `scan` never surfaces a seed on
  subscribe either — only on the first source emission.

So `complete` fired, the local `status` store went to `'success'`, and the
promise stayed unresolved forever. The result was a contradictory state:
`$status === 'success'` while `$data` was permanently `undefined`, with the
query stuck at `status: 'pending'` / `fetchStatus: 'fetching'`. It reproduced
in `useLatestEvent`/`useEvent`/`useArticle`/`useReplaceableEvent` whenever the
event genuinely did not exist, and in the `scanArray()`-based list hooks on a
zero-hit request.

Resolving on completion is the fix, but TanStack Query v5 rejects `undefined`
as query data (`data is undefined` error), so `null` is used as the "completed
with no events" sentinel and `.data` maps it back to `initData`.

That mapping fixes a second thing. `derived(query, fn, initData)`'s third
argument only holds until `fn` first runs, and `createQuery()`'s store emits
synchronously on subscribe — so `initData` was being overwritten with
`undefined` immediately and had no effect on the relay-configured path at all.
`$query.data ?? initData` makes it the value seen for the whole request, which
is what the list hooks passing `initData: []` already assumed.

## The missing initData

`useUniqueEventList()` was the only list hook not passing `initData: []`. On the
relay-less early return, `useReq()` hands `initData` straight back, so the hook
returned `readable(undefined)` against a declared `ReqResult<EventPacket[]>`.
`UniqueEventList` happens to guard with `$data?.length`, so this was invisible
through the component but a `TypeError` waiting for direct callers.

## Tests

Four regression tests, all verified to fail on `main`:

- `useReq`: the query settles (`status: 'success'`, `fetchStatus: 'idle'`) after
  an empty EOSE with `latest()`.
- `useReq`: resolves with `initData` after an empty EOSE with `scanArray()`,
  asserted against the query cache rather than `.data` — `.data` now falls back
  to `initData` while pending too, so it can't tell resolution apart from it.
- `useUniqueEventList`: `[]` after an empty EOSE, and `[]` with no relays
  configured.

`npm run lint`, `npm run test` (79 tests), and `npm run check` (0 errors) pass.

## Not included

`useReq()` never unsubscribes from the rx-nostr observable. For oneshot REQs
this is harmless — EOSE completes the stream and RxJS tears it down — but a
caller-supplied forward req never completes, so its subscription outlives the
component that created it. Fixing it properly needs a teardown hook `useReq()`
does not currently have, so it is filed separately rather than patched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)