### PR TITLE
fix(stores): close the REQ when a request is cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configured, matching the other list hooks and its own `EventPacket[]` return type.
   `UniqueEventList` was unaffected, but callers using the hook directly could hit a
   `TypeError` on the `undefined` the type said could not occur.
+- Cancelling a request now closes its REQ. A component unmounting before the relays
+  reach EOSE previously left the subscription — and the REQ on every relay in the
+  pool — open for the lifetime of the page.
 
 ## [0.6.0] - 2026-07-31
 

--- a/src/lib/stores/useReq.ts
+++ b/src/lib/stores/useReq.ts
@@ -46,11 +46,11 @@ export function useReq<A>({
   const obs = rxNostr.use(_req).pipe(operator);
   const query = createQuery<A, Error>({
     queryKey,
-    queryFn: () => {
+    queryFn: ({ signal }) => {
       return new Promise<A>((resolve, reject) => {
         let fulfilled = false;
 
-        obs.subscribe({
+        const subscription = obs.subscribe({
           next: (v) => {
             if (fulfilled) {
               queryClient.setQueryData(queryKey, v);
@@ -86,6 +86,12 @@ export function useReq<A>({
             }
           }
         });
+
+        // Reading `signal` opts this query into cancellation: when its last
+        // observer goes away while the fetch is still in flight — a component
+        // unmounting before the relays reach EOSE, or an explicit
+        // `cancelQueries()` — the REQ is closed instead of being left open.
+        signal.addEventListener('abort', () => subscription.unsubscribe());
       });
     }
   });

--- a/src/tests/stores/useReq.test.ts
+++ b/src/tests/stores/useReq.test.ts
@@ -174,6 +174,28 @@ describe('useReq', () => {
       expect(get(result.data)).toEqual([]);
     });
 
+    it('closes the REQ when the last subscriber leaves before the fetch settles', async () => {
+      const { rxNostr, server } = createTestRelay('ws://localhost:9007');
+      const result = useReq({
+        rxNostr,
+        queryKey: ['useReq', 'cancel'],
+        filters: [{ kinds: [1] }],
+        operator: pipe(),
+        initData: undefined
+      });
+      const unsubscribe = activate(result.status);
+
+      const subId = await nextReqSubId(server);
+
+      // Dropping the only subscriber while the query is still fetching stands
+      // in for a component unmounting before the relay reaches EOSE.
+      unsubscribe();
+
+      await vi.waitFor(() => {
+        expect(server.messages.at(-1)).toEqual(['CLOSE', subId]);
+      });
+    });
+
     it('sets .status to "error" and .error when the operator throws', async () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { rxNostr, server } = createTestRelay('ws://localhost:9003');


### PR DESCRIPTION
Follow-up to #59, on the same `useReq()` subscription.

`useReq()` called `obs.subscribe(...)` and threw the subscription away, so there
was no handle to tear it down with. A oneshot REQ recovers on its own — EOSE
completes the stream and RxJS unsubscribes — but nothing rescues a request whose
consumer disappears first. A component unmounting while the relays are still
responding left the subscription, and the REQ on every relay in the pool, alive
for the lifetime of the page.

The fix keeps the subscription and unsubscribes on the queryFn's `AbortSignal`.
Reading `signal` is what opts a query into TanStack Query's cancellation path:
`Query.removeObserver()` only cancels the in-flight retryer if the signal was
consumed. Cancellation is also a no-op once the retryer has settled, so this
cannot disturb an already-resolved query.

## Test

`useReq` sends `['CLOSE', subId]` after its last subscriber leaves mid-fetch,
verified to fail without the fix.

`npm run lint`, `npm run test` (80 tests), and `npm run check` (0 errors) pass.

## Scope

This covers cancellation, not the whole subscription lifetime. A caller-supplied
forward req that keeps emitting after the query has settled still has no
teardown path, because by then the query is resolved and unmounting no longer
cancels anything. Giving `useReq()` a real teardown hook is a separate design
question, filed as an issue rather than bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)