### PR TITLE
fix(stores): reset the error state when a request is retried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `error` no longer survives the request that produced it. A retry or refetch that
-  succeeded still reported the previous attempt's failure, and because every
-  component checks its `error` slot first, a recovered request kept rendering the
-  error slot instead of its data. `status` now also reports `'error'` when the
-  stream fails after the query has already resolved, which previously left
-  `status: 'success'` sitting next to a set `error`.
-
-### Fixed
-
 - A request whose filters match no event no longer hangs. Such a REQ reaches
   EOSE without the operator chain ever emitting, which left the underlying query
   pending forever: `status` reported `'success'` while `data` stayed `undefined`
@@ -31,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cancelling a request now closes its REQ. A component unmounting before the relays
   reach EOSE previously left the subscription — and the REQ on every relay in the
   pool — open for the lifetime of the page.
+- `error` no longer survives the request that produced it. A retry or refetch that
+  succeeded still reported the previous attempt's failure, and because every
+  component checks its `error` slot first, a recovered request kept rendering the
+  error slot instead of its data. `status` now also reports `'error'` when the
+  stream fails after the query has already resolved, which previously left
+  `status: 'success'` sitting next to a set `error`.
 
 ## [0.6.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `error` no longer survives the request that produced it. A retry or refetch that
+  succeeded still reported the previous attempt's failure, and because every
+  component checks its `error` slot first, a recovered request kept rendering the
+  error slot instead of its data. `status` now also reports `'error'` when the
+  stream fails after the query has already resolved, which previously left
+  `status: 'success'` sitting next to a set `error`.
+
+### Fixed
+
 - A request whose filters match no event no longer hangs. Such a REQ reaches
   EOSE without the operator chain ever emitting, which left the underlying query
   pending forever: `status` reported `'success'` while `data` stayed `undefined`

--- a/src/lib/stores/useReq.ts
+++ b/src/lib/stores/useReq.ts
@@ -41,12 +41,18 @@ export function useReq<A>({
   }
 
   const status = writable<ReqStatus>('loading');
-  const error = writable<Error>();
+  const error = writable<Error | undefined>();
 
   const obs = rxNostr.use(_req).pipe(operator);
   const query = createQuery<A, Error>({
     queryKey,
     queryFn: ({ signal }) => {
+      // Every attempt starts from a clean slate. These stores outlive a single
+      // fetch, so without this a retry or refetch that succeeds still reports
+      // the previous attempt's failure.
+      status.set('loading');
+      error.set(undefined);
+
       return new Promise<A>((resolve, reject) => {
         let fulfilled = false;
 
@@ -104,7 +110,13 @@ export function useReq<A>({
     // before the first emission, and maps the `null` resolved above back to it.
     data: derived(query, ($query) => ($query.data ?? initData) as A, initData),
     status: derived([query, status], ([$query, $status]) => {
-      if ($query.isSuccess) {
+      // The local store wins when it holds an error: a stream that fails after
+      // the query already resolved can't move `$query` off 'success', and
+      // reporting success next to a set `.error` is a state consumers can't
+      // make sense of.
+      if ($status === 'error') {
+        return 'error';
+      } else if ($query.isSuccess) {
         return 'success';
       } else if ($query.isError) {
         return 'error';
@@ -116,7 +128,7 @@ export function useReq<A>({
       if ($query.isError) {
         return $query.error;
       } else {
-        return $error;
+        return $error as Error;
       }
     })
   };

--- a/src/tests/stores/useReq.test.ts
+++ b/src/tests/stores/useReq.test.ts
@@ -222,6 +222,80 @@ describe('useReq', () => {
       expect(consoleError).toHaveBeenCalled();
     });
 
+    it('clears .error when a retried request succeeds', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      setQueryClientContext(
+        new QueryClient({ defaultOptions: { queries: { retry: 1, retryDelay: 0 } } })
+      );
+
+      const { rxNostr, server } = createTestRelay('ws://localhost:9008');
+      let attempt = 0;
+      const result = useReq<EventPacket>({
+        rxNostr,
+        queryKey: ['useReq', 'recovered'],
+        filters: [{ kinds: [1] }],
+        operator: map((packet: EventPacket) => {
+          if (attempt === 1) {
+            throw new Error('boom');
+          }
+          return packet;
+        })
+      });
+      activate(result.status);
+      activate(result.data);
+      activate(result.error);
+
+      attempt = 1;
+      respondWithEvent(server, await nextReqSubId(server), fakeEvent());
+      await waitFor(result.error, (e) => e !== undefined);
+
+      attempt = 2;
+      const retrySubId = await nextReqSubId(server);
+      const event = fakeEvent();
+      respondWithEvent(server, retrySubId, event);
+      respondWithEose(server, retrySubId);
+
+      expect((await waitFor(result.data, (v) => v !== undefined))?.event).toEqual(event);
+      expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+      // The failed attempt's error must not outlive it.
+      expect(get(result.error)).toBeUndefined();
+      expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('reports "error" as .status when the stream fails after the query resolved', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const { rxNostr, server } = createTestRelay('ws://localhost:9009');
+      let poisoned = false;
+      const result = useReq<EventPacket>({
+        rxNostr,
+        queryKey: ['useReq', 'late-error'],
+        filters: [{ kinds: [1] }],
+        operator: map((packet: EventPacket) => {
+          if (poisoned) {
+            throw new Error('late boom');
+          }
+          return packet;
+        })
+      });
+      activate(result.status);
+      activate(result.data);
+      activate(result.error);
+
+      const subId = await nextReqSubId(server);
+      respondWithEvent(server, subId, fakeEvent());
+      await waitFor(result.data, (v) => v !== undefined);
+
+      // The query has already resolved, so this failure can never reach it.
+      // `.status` has to follow the local store or it would claim success
+      // while `.error` is set.
+      poisoned = true;
+      respondWithEvent(server, subId, fakeEvent());
+
+      expect(await waitFor(result.status, (s) => s === 'error')).toBe('error');
+      expect(get(result.error)?.message).toBe('late boom');
+      expect(consoleError).toHaveBeenCalled();
+    });
+
     it('reuses a given req to emit filters instead of creating a new oneshot req', () => {
       const { rxNostr } = createTestRelay('ws://localhost:9004');
       const req = createRxForwardReq();


### PR DESCRIPTION
`useReq()`'s `status` and `error` writables live for as long as the hook call,
not for one fetch, and nothing ever cleared them. The returned `error` store
prefers the local value whenever the query itself isn't in an error state, so
once set it stayed set.

Two observable consequences, both verified against `main`:

| scenario | `status` | `data` | `error` |
| --- | --- | --- | --- |
| a retry succeeds after a failed attempt | `success` | `x2` | **`boom`** |
| the stream fails after the query resolved | `success` | `ok-1` | **`late boom`** |

Every component branches on `{#if $error}` before it looks at anything else
(`Text.svelte:32`, `EventList.svelte:32`, …), so a request that recovered kept
rendering the error slot instead of the data it was holding.

## Changes

- Reset `status` and `error` at the start of each attempt, so a retry or refetch
  starts clean.
- `status` now prefers a local error over the query's success. A stream failing
  after the query resolved cannot move the query off `'success'`, which left
  `status: 'success'` next to a set `error` — a state a consumer has no way to
  act on. It now reports `'error'`, agreeing with `error`.

## Tests

Two regression tests, both verified to fail without the fix:

- `.error` is cleared once a retried request succeeds.
- `.status` becomes `'error'` when the stream fails after the query resolved.

`npm run lint`, `npm run test` (82 tests), and `npm run check` (0 errors) pass.

Found while auditing `src/lib/stores/` for more of the classes fixed in #59
and #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)