### PR TITLE
fix(stores): resolve the "d" tag by name, not by position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error slot instead of its data. `status` now also reports `'error'` when the
   stream fails after the query has already resolved, which previously left
   `status: 'success'` sitting next to a set `error`.
+- Addressable events are now identified by their `d` tag wherever it appears in the
+  tag list, instead of assuming it is the first tag. `useArticle()`/`Article` returned
+  nothing at all for an article that led with any other tag (`title`, say), and
+  `useUserArticleList()`/`useUserReactionList()` silently dropped events that happened
+  to share a leading tag value.
 
 ## [0.6.0] - 2026-07-31
 

--- a/src/lib/stores/operators.ts
+++ b/src/lib/stores/operators.ts
@@ -3,10 +3,21 @@
  * @copyright 2023 Akiomi Kamakura
  */
 
+import type Nostr from 'nostr-typedef';
 import type { EventPacket } from 'rx-nostr';
 import { latestEach } from 'rx-nostr';
 import type { OperatorFunction } from 'rxjs';
 import { filter, map, pipe, scan } from 'rxjs';
+
+/**
+ * The `d` tag value that addresses a parameterized replaceable event.
+ *
+ * NIP-01 places no constraint on where the tag sits, so it has to be looked up
+ * by name; an event without one is addressed as if its identifier were empty.
+ */
+function identifierOf({ tags }: Nostr.Event): string {
+  return tags.find(([name]) => name === 'd')?.[1] ?? '';
+}
 
 export function filterId(id: string): OperatorFunction<EventPacket, EventPacket> {
   return filter((packet) => packet.event.id === id);
@@ -31,7 +42,7 @@ export function filterNaddr(
 ): OperatorFunction<EventPacket, EventPacket> {
   return filter(
     ({ event }) =>
-      event.kind === kind && event.pubkey === pubkey && event.tags[0]?.[1] === identifier
+      event.kind === kind && event.pubkey === pubkey && identifierOf(event) === identifier
   );
 }
 
@@ -40,7 +51,7 @@ export function latestEachPubkey(): OperatorFunction<EventPacket, EventPacket> {
 }
 
 export function latestEachNaddr(): OperatorFunction<EventPacket, EventPacket> {
-  return latestEach(({ event }) => `${event.kind}:${event.pubkey}:${event.tags[0]?.[1]}`);
+  return latestEach(({ event }) => `${event.kind}:${event.pubkey}:${identifierOf(event)}`);
 }
 
 export function scanArray<A>(): OperatorFunction<A, A[]> {

--- a/src/tests/stores/operators.test.ts
+++ b/src/tests/stores/operators.test.ts
@@ -86,6 +86,35 @@ describe('filterNaddr', () => {
 
     expect(actual).toEqual([matching]);
   });
+
+  it('finds the "d" tag wherever it sits in the tag list', async () => {
+    // NIP-01 doesn't require `d` to come first, and long-form clients routinely
+    // put `title` ahead of it.
+    const matching = fakeEventPacket({
+      kind: 30023,
+      pubkey: 'p1',
+      tags: [
+        ['title', 'Hello'],
+        ['d', 'article-1']
+      ]
+    });
+
+    const actual = await lastValueFrom(
+      from([matching]).pipe(filterNaddr(30023, 'p1', 'article-1'), toArray())
+    );
+
+    expect(actual).toEqual([matching]);
+  });
+
+  it('treats an event without a "d" tag as having an empty identifier', async () => {
+    const noDTag = fakeEventPacket({ kind: 30023, pubkey: 'p1', tags: [['title', 'Hello']] });
+
+    const actual = await lastValueFrom(
+      from([noDTag]).pipe(filterNaddr(30023, 'p1', ''), toArray())
+    );
+
+    expect(actual).toEqual([noDTag]);
+  });
 });
 
 describe('latestEachPubkey', () => {
@@ -139,6 +168,36 @@ describe('latestEachNaddr', () => {
     );
 
     expect(actual).toEqual([first, newer, otherIdentifier]);
+  });
+
+  it('keys off the "d" tag wherever it sits, so distinct articles stay distinct', async () => {
+    // Both articles lead with the same hashtag; only the `d` tag tells them
+    // apart. Relays answer newest-first, so the older one arrives second and
+    // would be dropped as stale if they shared a key.
+    const newer = fakeEventPacket({
+      id: 'e1',
+      kind: 30023,
+      pubkey: 'p1',
+      created_at: 2,
+      tags: [
+        ['t', 'nostr'],
+        ['d', 'article-1']
+      ]
+    });
+    const older = fakeEventPacket({
+      id: 'e2',
+      kind: 30023,
+      pubkey: 'p1',
+      created_at: 1,
+      tags: [
+        ['t', 'nostr'],
+        ['d', 'article-2']
+      ]
+    });
+
+    const actual = await lastValueFrom(from([newer, older]).pipe(latestEachNaddr(), toArray()));
+
+    expect(actual).toEqual([newer, older]);
   });
 });
 

--- a/src/tests/stores/useArticle.test.ts
+++ b/src/tests/stores/useArticle.test.ts
@@ -1,0 +1,77 @@
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useArticle } from '$lib/stores/useArticle.js';
+
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, waitFor } from '../helpers/store.js';
+
+describe('useArticle', () => {
+  beforeEach(() => {
+    setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('resolves the article whose "d" tag matches, whatever its position', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9310');
+    const identifier = 'my-article';
+
+    const result = useArticle(rxNostr, ['useArticle'], 'p1', identifier);
+    activate(result.status);
+    activate(result.data);
+
+    const subId = await nextReqSubId(server);
+    expect(server.messages.at(-1)).toEqual([
+      'REQ',
+      subId,
+      { kinds: [30023], authors: ['p1'], '#d': [identifier], limit: 1 }
+    ]);
+
+    // Long-form clients commonly emit `title` before `d`.
+    const event = fakeEvent({
+      kind: 30023,
+      pubkey: 'p1',
+      tags: [
+        ['title', 'My Article'],
+        ['d', identifier]
+      ]
+    });
+    respondWithEvent(server, subId, event);
+
+    const data = await waitFor(result.data, (v) => v !== undefined);
+    expect(data?.event).toEqual(event);
+
+    respondWithEose(server, subId);
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+  });
+
+  it('ignores an article of the same kind and author with a different identifier', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9311');
+
+    const result = useArticle(rxNostr, ['useArticle', 'other'], 'p1', 'wanted');
+    activate(result.status);
+    activate(result.data);
+
+    const subId = await nextReqSubId(server);
+    respondWithEvent(
+      server,
+      subId,
+      fakeEvent({ kind: 30023, pubkey: 'p1', tags: [['d', 'not-wanted']] })
+    );
+    respondWithEose(server, subId);
+
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
`filterNaddr()` and `latestEachNaddr()` read an addressable event's identifier
as `event.tags[0]?.[1]` (`operators.ts:34`, `operators.ts:43`). NIP-01 places no
constraint on where the `d` tag sits, and long-form clients routinely lead with
`title`.

Two consequences, both verified against `main`:

- **`useArticle()` returns nothing at all.** Given a kind-30023 event tagged
  `[['title', 'My Article'], ['d', 'my-article']]`, the relay answers the REQ
  correctly — the filter already uses `'#d'` — and then `filterNaddr()` rejects
  every packet. `$data` stays `undefined`. Before #59 this presented as a
  request that hung forever.
- **`useUserArticleList()`/`useUserReactionList()` drop events.** The group key
  becomes whatever the first tag holds, so two distinct articles that lead with
  the same hashtag land in one group and the older one is discarded as stale.
  Relays answer newest-first, so the discarded one is the common case.

## Changes

`identifierOf()` looks the tag up by name and treats an event without one as
having an empty identifier, which is how NIP-01 addresses it.

## Tests

Four regression tests, all verified to fail without the fix:

- `filterNaddr` matches when `d` is not the first tag, and treats a missing `d`
  as the empty identifier.
- `latestEachNaddr` keeps two articles distinct when they share a leading tag.
- New `useArticle` suite: resolves an article whose `d` follows `title`, and
  still ignores one with a different identifier.

`npm run lint`, `npm run test` (85 tests), and `npm run check` (0 errors) pass.

Found while auditing `src/lib/stores/` for more of the classes fixed in #59
and #60. Independent of #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)