### PR TITLE
fix(stores): keep one entry per key in the list hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing at all for an article that led with any other tag (`title`, say), and
   `useUserArticleList()`/`useUserReactionList()` silently dropped events that happened
   to share a leading tag value.
+- `useMetadataList()` and `useUserArticleList()` now replace an entry when a newer
+  version of the same event arrives, instead of appending it next to the version it
+  supersedes. Both could return several entries for one pubkey or one article.
+- `useUserReactionList()` no longer groups reactions as if they were addressable
+  events. Reactions are regular events, so keying them by an event coordinate
+  collapsed unrelated ones together — three reactions could come back as one. They
+  are now deduplicated by event id only.
 
 ## [0.6.0] - 2026-07-31
 

--- a/src/lib/stores/operators.ts
+++ b/src/lib/stores/operators.ts
@@ -50,8 +50,12 @@ export function latestEachPubkey(): OperatorFunction<EventPacket, EventPacket> {
   return latestEach(({ event }) => event.pubkey);
 }
 
+function naddrOf(event: Nostr.Event): string {
+  return `${event.kind}:${event.pubkey}:${identifierOf(event)}`;
+}
+
 export function latestEachNaddr(): OperatorFunction<EventPacket, EventPacket> {
-  return latestEach(({ event }) => `${event.kind}:${event.pubkey}:${identifierOf(event)}`);
+  return latestEach(({ event }) => naddrOf(event));
 }
 
 export function scanArray<A>(): OperatorFunction<A, A[]> {
@@ -82,5 +86,31 @@ export function scanLatestEach<A, K>(f: (a: A) => K): OperatorFunction<A, A[]> {
     collectGroupBy(f),
     // dict values are never empty: collectGroupBy always seeds a group with its first element
     map((dict) => Array.from(dict.entries()).map(([, value]) => value.slice(-1)[0] as A))
+  );
+}
+
+/**
+ * Accumulate packets into a list holding the newest event per pubkey.
+ *
+ * `latestEachPubkey()` re-emits whenever a newer event for a pubkey arrives, so
+ * accumulating it with `scanArray()` would append the update next to the event
+ * it supersedes instead of replacing it.
+ */
+export function scanLatestEachPubkey(): OperatorFunction<EventPacket, EventPacket[]> {
+  return pipe(
+    latestEachPubkey(),
+    scanLatestEach(({ event }) => event.pubkey)
+  );
+}
+
+/**
+ * Accumulate packets into a list holding the newest event per addressable
+ * event coordinate. See {@link scanLatestEachPubkey} for why plain
+ * accumulation is not enough.
+ */
+export function scanLatestEachNaddr(): OperatorFunction<EventPacket, EventPacket[]> {
+  return pipe(
+    latestEachNaddr(),
+    scanLatestEach(({ event }) => naddrOf(event))
   );
 }

--- a/src/lib/stores/useMetadataList.ts
+++ b/src/lib/stores/useMetadataList.ts
@@ -7,7 +7,7 @@ import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
-import { filterMetadataList, latestEachPubkey, scanArray } from './operators.js';
+import { filterMetadataList, scanLatestEachPubkey } from './operators.js';
 import type { ReqResult, RxReqBase } from './types.js';
 import { useReq } from './useReq.js';
 
@@ -19,6 +19,6 @@ export function useMetadataList(
 ): ReqResult<EventPacket[]> {
   // TODO: Add npub support
   const filters = [{ kinds: [0], authors: pubkeys, limit: pubkeys.length }];
-  const operator = pipe(filterMetadataList(pubkeys), latestEachPubkey(), scanArray());
+  const operator = pipe(filterMetadataList(pubkeys), scanLatestEachPubkey());
   return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }

--- a/src/lib/stores/useUserArticleList.ts
+++ b/src/lib/stores/useUserArticleList.ts
@@ -8,7 +8,7 @@ import type { EventPacket, RxNostr } from 'rx-nostr';
 import { filterByKind } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
-import { filterPubkey, latestEachNaddr, scanArray } from './operators.js';
+import { filterPubkey, scanLatestEachNaddr } from './operators.js';
 import type { ReqResult, RxReqBase } from './types.js';
 import { useReq } from './useReq.js';
 
@@ -20,6 +20,6 @@ export function useUserArticleList(
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket[]> {
   const filters = [{ kinds: [30023], authors: [pubkey], limit }];
-  const operator = pipe(filterByKind(30023), filterPubkey(pubkey), latestEachNaddr(), scanArray());
+  const operator = pipe(filterByKind(30023), filterPubkey(pubkey), scanLatestEachNaddr());
   return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }

--- a/src/lib/stores/useUserReactionList.ts
+++ b/src/lib/stores/useUserReactionList.ts
@@ -5,10 +5,10 @@
 
 import type { QueryKey } from '@tanstack/svelte-query';
 import type { EventPacket, RxNostr } from 'rx-nostr';
-import { filterByKind } from 'rx-nostr';
+import { filterByKind, uniq } from 'rx-nostr';
 import { pipe } from 'rxjs';
 
-import { filterPubkey, latestEachNaddr, scanArray } from './operators.js';
+import { filterPubkey, scanArray } from './operators.js';
 import type { ReqResult, RxReqBase } from './types.js';
 import { useReq } from './useReq.js';
 
@@ -20,6 +20,9 @@ export function useUserReactionList(
   req?: RxReqBase | undefined
 ): ReqResult<EventPacket[]> {
   const filters = [{ kinds: [7], authors: [pubkey], limit }];
-  const operator = pipe(filterByKind(7), filterPubkey(pubkey), latestEachNaddr(), scanArray());
+  // Reactions are regular events, not addressable ones, so they are only
+  // deduplicated by id; grouping them by an event coordinate would collapse
+  // unrelated reactions into one.
+  const operator = pipe(filterByKind(7), filterPubkey(pubkey), uniq(), scanArray());
   return useReq({ rxNostr, queryKey, filters, operator, req, initData: [] });
 }

--- a/src/tests/stores/useMetadataList.test.ts
+++ b/src/tests/stores/useMetadataList.test.ts
@@ -1,0 +1,59 @@
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useMetadataList } from '$lib/stores/useMetadataList.js';
+
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, waitFor } from '../helpers/store.js';
+
+describe('useMetadataList', () => {
+  beforeEach(() => {
+    setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('keeps one entry per pubkey when an updated metadata arrives', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9312');
+    const pubkeys = ['p1', 'p2'];
+
+    const result = useMetadataList(rxNostr, ['useMetadataList'], pubkeys);
+    activate(result.status);
+    activate(result.data);
+
+    const subId = await nextReqSubId(server);
+    expect(server.messages.at(-1)).toEqual([
+      'REQ',
+      subId,
+      { kinds: [0], authors: pubkeys, limit: pubkeys.length }
+    ]);
+
+    const stale = fakeEvent({ id: 'm1', kind: 0, pubkey: 'p1', created_at: 1, content: 'stale' });
+    respondWithEvent(server, subId, stale);
+    await waitFor(result.data, (v) => v.length === 1);
+
+    const other = fakeEvent({ id: 'm2', kind: 0, pubkey: 'p2', created_at: 1 });
+    respondWithEvent(server, subId, other);
+    await waitFor(result.data, (v) => v.length === 2);
+
+    // An update for a pubkey already in the list must replace its entry, not
+    // sit next to the event it supersedes.
+    const fresh = fakeEvent({ id: 'm3', kind: 0, pubkey: 'p1', created_at: 2, content: 'fresh' });
+    respondWithEvent(server, subId, fresh);
+    await waitFor(result.data, (v) => v.some((p) => p.event.id === fresh.id));
+
+    respondWithEose(server, subId);
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data).map((p) => p.event)).toEqual([fresh, other]);
+  });
+});

--- a/src/tests/stores/useUserArticleList.test.ts
+++ b/src/tests/stores/useUserArticleList.test.ts
@@ -1,0 +1,71 @@
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useUserArticleList } from '$lib/stores/useUserArticleList.js';
+
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, waitFor } from '../helpers/store.js';
+
+const article = (id: string, identifier: string, created_at: number) =>
+  fakeEvent({
+    id,
+    kind: 30023,
+    pubkey: 'p1',
+    created_at,
+    tags: [
+      ['t', 'nostr'],
+      ['d', identifier]
+    ]
+  });
+
+describe('useUserArticleList', () => {
+  beforeEach(() => {
+    setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('keeps one entry per article, replacing an article with its newer revision', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9314');
+
+    const result = useUserArticleList(rxNostr, ['useUserArticleList'], 'p1', 10);
+    activate(result.status);
+    activate(result.data);
+
+    const subId = await nextReqSubId(server);
+    expect(server.messages.at(-1)).toEqual([
+      'REQ',
+      subId,
+      { kinds: [30023], authors: ['p1'], limit: 10 }
+    ]);
+
+    // Two distinct articles that lead with the same tag, newest first as a
+    // relay would send them.
+    const first = article('a1', 'article-1', 200);
+    respondWithEvent(server, subId, first);
+    await waitFor(result.data, (v) => v.length === 1);
+
+    const second = article('a2', 'article-2', 100);
+    respondWithEvent(server, subId, second);
+    await waitFor(result.data, (v) => v.length === 2);
+
+    // A revision of the first article replaces it rather than joining it.
+    const revised = article('a3', 'article-1', 300);
+    respondWithEvent(server, subId, revised);
+    await waitFor(result.data, (v) => v.some((p) => p.event.id === revised.id));
+
+    respondWithEose(server, subId);
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data).map((p) => p.event)).toEqual([revised, second]);
+  });
+});

--- a/src/tests/stores/useUserReactionList.test.ts
+++ b/src/tests/stores/useUserReactionList.test.ts
@@ -1,0 +1,81 @@
+import { QueryClient, setQueryClientContext } from '@tanstack/svelte-query';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WS from 'vitest-websocket-mock';
+
+import { useUserReactionList } from '$lib/stores/useUserReactionList.js';
+
+import {
+  createTestRelay,
+  fakeEvent,
+  nextReqSubId,
+  respondWithEose,
+  respondWithEvent
+} from '../helpers/relay.js';
+import { activate, waitFor } from '../helpers/store.js';
+
+describe('useUserReactionList', () => {
+  beforeEach(() => {
+    setQueryClientContext(new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('keeps every distinct reaction, deduplicating only by event id', async () => {
+    const { rxNostr, server } = createTestRelay('ws://localhost:9313');
+
+    const result = useUserReactionList(rxNostr, ['useUserReactionList'], 'p1', 10);
+    activate(result.status);
+    activate(result.data);
+
+    const subId = await nextReqSubId(server);
+    expect(server.messages.at(-1)).toEqual([
+      'REQ',
+      subId,
+      { kinds: [7], authors: ['p1'], limit: 10 }
+    ]);
+
+    // Reactions are regular events. These three share nothing that identifies
+    // them as versions of one another: one carries no tags at all, and the two
+    // tagged ones lead with the same `p` tag while pointing at different notes.
+    const untagged = fakeEvent({ id: 'r1', kind: 7, pubkey: 'p1', created_at: 300, content: '+' });
+    const toNote1 = fakeEvent({
+      id: 'r2',
+      kind: 7,
+      pubkey: 'p1',
+      created_at: 200,
+      content: '+',
+      tags: [
+        ['p', 'author'],
+        ['e', 'note-1']
+      ]
+    });
+    const toNote2 = fakeEvent({
+      id: 'r3',
+      kind: 7,
+      pubkey: 'p1',
+      created_at: 100,
+      content: '+',
+      tags: [
+        ['p', 'author'],
+        ['e', 'note-2']
+      ]
+    });
+
+    respondWithEvent(server, subId, untagged);
+    await waitFor(result.data, (v) => v.length === 1);
+    respondWithEvent(server, subId, toNote1);
+    await waitFor(result.data, (v) => v.length === 2);
+    respondWithEvent(server, subId, toNote2);
+    await waitFor(result.data, (v) => v.length === 3);
+
+    // A resend of one of them is still a duplicate.
+    respondWithEvent(server, subId, toNote1);
+    respondWithEose(server, subId);
+
+    expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    expect(get(result.data).map((p) => p.event)).toEqual([untagged, toNote1, toNote2]);
+  });
+});


### PR DESCRIPTION
Stacked on #63 — the article list can only be grouped correctly once the `d`
tag is resolved correctly, so this branch builds on it. Its base retargets to
`main` once #63 merges.

## Duplicate entries

`latestEach*()` re-emits whenever a newer event for a key arrives — the existing
`latestEachPubkey` test asserts exactly that, expecting `[first, newer, other]`.
Pairing it with `scanArray()` therefore *appends* the update next to the event
it supersedes:

```
useMetadataList(['p1']) after a metadata update
  → [['p1', 'old'], ['p1', 'new']]      // two entries for one pubkey
```

Accumulating with `scanLatestEach()` — already in `operators.ts` and already
used by `useConnections` — gives one entry per key with the newest winning. The
two compositions are now named operators (`scanLatestEachPubkey`,
`scanLatestEachNaddr`) so the key function and the accumulation stay defined
together rather than being re-derived at each call site.

## Reactions grouped as addressable events

`useUserReactionList()` piped kind-7 events through `latestEachNaddr()`.
Reactions are regular events; keying them by an event coordinate collapses
unrelated ones into a single group, and only the newest of each group survives:

```
three reactions by p1 (one untagged, two to different notes)
  → 1 entry
```

They are now deduplicated by event id with `uniq()`, matching
`useUserTextList()`, the other regular-event list hook.

## Tests

Three new hook suites, all verified to fail without the fix:

- `useMetadataList` replaces a pubkey's entry on update rather than appending.
- `useUserArticleList` keeps two articles sharing a leading tag distinct, and
  replaces an article with its newer revision.
- `useUserReactionList` keeps three distinct reactions and still drops a resend.

`npm run lint`, `npm run test` (88 tests), and `npm run check` (0 errors) pass.

## Follow-up, not in this PR

While writing these tests I found that `useReq()` loses every event that arrives
between the first one and the moment the query settles: those go through
`setQueryData()`, and TanStack Query then overwrites the cache with the value
the queryFn promise resolved with. Events arriving after the query has settled
are fine. Filing separately — it needs a change to how streaming writes and the
promise resolution interact, not a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)