### PR TITLE
fix(stores): keep events delivered in the first batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   events. Reactions are regular events, so keying them by an event coordinate
   collapsed unrelated ones together — three reactions could come back as one. They
   are now deduplicated by event id only.
+- Events delivered in the same batch as the first one are no longer dropped. They
+  reached the query cache before the request had settled and were then overwritten
+  by the value it settled with, so a relay flushing a backlog in one go could leave
+  a list holding only its first event.
 
 ## [0.6.0] - 2026-07-31
 

--- a/src/lib/stores/useReq.ts
+++ b/src/lib/stores/useReq.ts
@@ -55,14 +55,22 @@ export function useReq<A>({
 
       return new Promise<A>((resolve, reject) => {
         let fulfilled = false;
+        let latest: A;
 
         const subscription = obs.subscribe({
           next: (v) => {
+            latest = v;
+
             if (fulfilled) {
               queryClient.setQueryData(queryKey, v);
             } else {
-              resolve(v);
               fulfilled = true;
+              // Resolving synchronously would pin the query to this first
+              // value: anything the relays deliver in the same task reaches
+              // `setQueryData()` before the resolution is processed, and is
+              // then overwritten by it. Deferring to a microtask lets the whole
+              // batch land first.
+              queueMicrotask(() => resolve(latest));
             }
           },
           complete: () => {

--- a/src/tests/stores/useReq.test.ts
+++ b/src/tests/stores/useReq.test.ts
@@ -196,6 +196,33 @@ describe('useReq', () => {
       });
     });
 
+    it('keeps events that arrive in the same batch as the first one', async () => {
+      const { rxNostr, server } = createTestRelay('ws://localhost:9010');
+      const result = useReq<EventPacket[]>({
+        rxNostr,
+        queryKey: ['useReq', 'batch'],
+        filters: [{ kinds: [1] }],
+        operator: pipe(scanArray()),
+        initData: []
+      });
+      activate(result.status);
+      activate(result.data);
+
+      // Delivered without yielding, the way a relay flushing a backlog can
+      // reach the client. The second and third would land in the cache before
+      // the query settled and be overwritten by the value it resolved with.
+      const subId = await nextReqSubId(server);
+      const events = [fakeEvent(), fakeEvent(), fakeEvent()];
+      for (const event of events) {
+        respondWithEvent(server, subId, event);
+      }
+      respondWithEose(server, subId);
+
+      const data = await waitFor(result.data, (v) => v.length === events.length);
+      expect(data.map((p) => p.event)).toEqual(events);
+      expect(await waitFor(result.status, (s) => s === 'success')).toBe('success');
+    });
+
     it('sets .status to "error" and .error when the operator throws', async () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { rxNostr, server } = createTestRelay('ws://localhost:9003');


### PR DESCRIPTION
Found while writing the list-hook tests in #64.

`useReq()` resolved its queryFn promise synchronously with the first value the
operator chain emitted. Every later value takes the `setQueryData()` path — but
until the promise resolution has been processed, that writes to a query that has
not settled, and TanStack Query then overwrites the cache with the value the
promise resolved with.

So everything delivered in the same task as the first event was silently lost:

```
three EVENTs sent without yielding  → ["a"]
the same three, one task apart      → ["a", "b", "c"]
three sent after the query settled  → all kept
```

A relay flushing a backlog in one read could leave a list holding only its first
event.

## Change

Track the latest emitted value and resolve on a microtask instead of
synchronously. The rest of the batch lands via `setQueryData()` first, and the
promise then settles on the accumulated value rather than the stale first one.
Events arriving in later tasks are unaffected — by then the query has settled
and `setQueryData()` is authoritative, which is why they always worked.

## Test

`useReq` keeps all three events when they are delivered without yielding,
verified to fail without the fix.

`npm run lint`, `npm run test` (81 tests), and `npm run check` (0 errors) pass.

Independent of #62, #63 and #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)