### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-31
+
 ### Fixed
 
 - A request whose filters match no event no longer hangs. Such a REQ reaches
@@ -116,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Vitest 3, ESLint 10, Prettier 3) and moved CI to Node.js 26. This does not
   affect the published package.
 
-[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/akiomik/nosvelte/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/akiomik/nosvelte/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/akiomik/nosvelte/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/akiomik/nosvelte/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/akiomik/nosvelte/compare/v0.3.0...v0.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nosvelte",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nosvelte",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/svelte-query": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosvelte",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "Akiomi Kamakura <akiomik@gmail.com>",
   "description": "An experimental Svelte library for building Nostr apps easily",
   "license": "Apache-2.0",


### PR DESCRIPTION
A patch release of correctness fixes to `src/lib/stores/`. No API changes, no
dependency changes.

## What's in it

Six fixes, each with regression tests verified to fail beforehand:

- **Requests that match nothing no longer hang** (#59). A REQ that reaches EOSE
  without the operator chain ever emitting left the query pending forever —
  `status` said `'success'` while `data` stayed `undefined`. Affected
  `useLatestEvent`/`useEvent`/`useArticle`/`useReplaceableEvent` whenever the
  event genuinely did not exist.
- **`useUniqueEventList()` yields `[]` with no relays configured** (#59),
  matching the other list hooks and its own return type.
- **Cancelling a request closes its REQ** (#60). Unmounting before EOSE used to
  leave the subscription, and the REQ on every relay, open for the life of the
  page.
- **`error` no longer outlives the request that produced it** (#62). A retry
  that succeeded still reported the failure, and since every component checks
  its error slot first, a recovered request kept rendering that slot instead of
  its data.
- **Addressable events are identified by their `d` tag by name** (#63), not by
  assuming it is the first tag. `useArticle()` returned *nothing at all* for an
  article that led with `title`.
- **List hooks keep one entry per key, and reactions are no longer grouped as
  addressable events** (#64). `useMetadataList()` could return two entries for
  one pubkey; `useUserReactionList()` could collapse three unrelated reactions
  into one.
- **Events delivered in the same batch as the first are no longer dropped**
  (#65). They reached the cache before the request settled and were overwritten
  by the value it settled with, so a relay flushing a backlog in one go left a
  list holding only its first event.

## Verification

`npm run lint`, `npm run test` (90 tests), `npm run check` (0 errors), and
`npm run build` (publint: all good, packaged as 0.6.1) all pass.

## Known issues, not fixed here

Filed as follow-ups rather than rushed into a patch:

- Passing a `req` to any hook or component sends no REQ at all — `useReq()`
  emits the filters before anything subscribes. Fixing it changes how `req` is
  wired.
- `useEventList()` silently drops anything that isn't kind 1; deciding between
  making it kind-agnostic and renaming it is an API question.
- `ReqResult`'s `data`/`error` are typed non-optional but are `undefined` in
  practice. Making the types honest is breaking for TypeScript consumers.
- `useReq()` still has no teardown once a query has settled (#61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)