### PR TITLE
fix(stores): emit a given req's filters once something is subscribed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `useConnections()` was the one with no bound — it lives for the whole page and
   takes a packet for every relay connection-state change — while
   `useMetadataList()` and `useUserArticleList()` paid it per request.
+- Passing a `req` to a hook or component now actually issues the request. The
+  filters were emitted before anything had subscribed, so they were dropped and no
+  REQ ever reached the relays — every hook given a `req` stayed `'loading'` forever.
+  They are emitted once the subscription exists instead.
 
 ## [0.6.1] - 2026-07-31
 

--- a/src/lib/stores/useReq.ts
+++ b/src/lib/stores/useReq.ts
@@ -32,13 +32,9 @@ export function useReq<A>({
     };
   }
 
-  let _req: RxReq;
-  if (req) {
-    req.emit(filters);
-    _req = req;
-  } else {
-    _req = createRxOneshotReq({ filters });
-  }
+  // A caller-supplied req is emitted to further down, once something is
+  // listening. A oneshot req carries its filters from the start.
+  const _req: RxReq = req ?? createRxOneshotReq({ filters });
 
   const status = writable<ReqStatus>('loading');
   const error = writable<Error | undefined>();
@@ -106,6 +102,11 @@ export function useReq<A>({
         // unmounting before the relays reach EOSE, or an explicit
         // `cancelQueries()` — the REQ is closed instead of being left open.
         signal.addEventListener('abort', () => subscription.unsubscribe());
+
+        // Only now is there anything listening. Emitting when `useReq()` was
+        // called happened before this subscription existed, so a forward req
+        // dropped the filters on the floor and no REQ was ever sent.
+        req?.emit(filters);
       });
     }
   });

--- a/src/tests/stores/useReq.test.ts
+++ b/src/tests/stores/useReq.test.ts
@@ -323,19 +323,12 @@ describe('useReq', () => {
       expect(consoleError).toHaveBeenCalled();
     });
 
-    it('reuses a given req to emit filters instead of creating a new oneshot req', () => {
-      const { rxNostr } = createTestRelay('ws://localhost:9004');
-      const req = createRxForwardReq();
-      const emitSpy = vi.spyOn(req, 'emit');
+    it('sends a REQ through a given req instead of creating a new oneshot req', async () => {
+      const { rxNostr, server } = createTestRelay('ws://localhost:9004');
+      const req = createRxForwardReq('given');
       const filters = [{ kinds: [1] }];
 
-      // `req`'s own packet stream is the source of truth for what useReq()
-      // asked it to emit, independent of whether/when the internal query
-      // machinery subscribes to it.
-      const packets: unknown[] = [];
-      const subscription = req.getReqPacketObservable().subscribe((packet) => packets.push(packet));
-
-      useReq({
+      const result = useReq({
         rxNostr,
         queryKey: ['useReq', 'req-reuse'],
         filters,
@@ -343,11 +336,46 @@ describe('useReq', () => {
         req,
         initData: undefined
       });
+      activate(result.status);
+      activate(result.data);
 
-      expect(emitSpy).toHaveBeenCalledWith(filters);
-      expect(packets).toEqual([{ filters }]);
+      // Asserted against the relay rather than the req's own packet stream:
+      // `emit()` reaching the req says nothing about a REQ being sent, which is
+      // how this went unnoticed while no request was going out at all.
+      const subId = await nextReqSubId(server);
+      expect(subId).toBe('given:0');
+      expect(server.messages.at(-1)).toEqual(['REQ', subId, filters[0]]);
 
-      subscription.unsubscribe();
+      const event = fakeEvent();
+      respondWithEvent(server, subId, event);
+      expect((await waitFor(result.data, (v) => v !== undefined))?.event).toEqual(event);
+    });
+
+    it('keeps a given forward req open past EOSE', async () => {
+      const { rxNostr, server } = createTestRelay('ws://localhost:9011');
+      const result = useReq({
+        rxNostr,
+        queryKey: ['useReq', 'req-forward'],
+        filters: [{ kinds: [1] }],
+        operator: pipe(),
+        req: createRxForwardReq('live'),
+        initData: undefined
+      });
+      activate(result.status);
+      activate(result.data);
+
+      const subId = await nextReqSubId(server);
+      respondWithEvent(server, subId, fakeEvent());
+      await waitFor(result.data, (v) => v !== undefined);
+
+      // The point of passing a forward req: EOSE ends the stored-events phase
+      // but not the subscription.
+      respondWithEose(server, subId);
+      const live = fakeEvent();
+      respondWithEvent(server, subId, live);
+
+      const data = await waitFor(result.data, (v) => v?.event.id === live.id);
+      expect(data?.event).toEqual(live);
     });
   });
 });


### PR DESCRIPTION
Closes #67.

`useReq()` called `req.emit(filters)` while setting up, before anything had
subscribed to `rxNostr.use(req)` — the query's `queryFn` only subscribes once a
component reads one of the returned stores. A forward req has no listener at
that point, so the filters went nowhere and no REQ ever reached the relays.

Same hook, same relay, with and without a `req`, on v0.6.1:

```
useUserTextList(..., createRxForwardReq('fwd'))  → messages: []      status: 'loading'
useUserTextList(...)                             → messages: ['REQ']
```

Every hook and component given a `req` — `<Text {req}>`, `<Metadata {req}>`, … —
sat at `'loading'` indefinitely.

## Change

Emit from inside the queryFn, after the subscription exists. Four lines moved;
no API or type change.

## Tests

The test that covered this — "reuses a given req to emit filters instead of
creating a new oneshot req" — asserted that `emit()` had been called and that
the packet appeared on the req's own observable. Both were true the entire time
a request was going nowhere, which is how this went unnoticed. It now asserts
against the relay: a REQ arrives, carrying the given req's subId (`given:0`, not
a generated oneshot id) and the requested filters, and an event sent back reaches
`.data`.

A second test covers what passing a forward req is actually for: an event
delivered after EOSE still updates `.data`, because the subscription outlives the
stored-events phase.

Both fail without the fix — they time out waiting for a REQ that never arrives.

`npm run lint`, `npm run test` (95 tests), and `npm run check` (0 errors) pass.

## Still not supported: one req shared by several hooks

#67 also noted that two hooks sharing a `req` clobber each other's filters. This
changes that symptom without resolving it. Before, one REQ went out carrying the
second hook's filters; now both hooks emit, but they share one `rxReqId`, so both
REQs use the same subId and the second replaces the first:

```
useMetadata(..., shared) + useUserTextList(..., shared)
  → REQ shared:0 {"kinds":[0],"authors":["p1"],"limit":1}
  → REQ shared:0 {"kinds":[1],"authors":["p1"],"limit":10}
```

Each hook's filters at least reach the relay now, but a subscription id can only
carry one filter set. Supporting this needs a rxReqId per consumer, which is a
separate change — I'll file it once this merges rather than widen this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)